### PR TITLE
Add custom months entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13086,6 +13086,7 @@
       "version": "2.13.9",
       "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
       "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
+      "deprecated": "Package moved to @redux-devtools/extension.",
       "peerDependencies": {
         "redux": "^3.1.0 || ^4.0.0"
       }
@@ -14001,7 +14002,8 @@
     "node_modules/source-map-url": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
-      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "deprecated": "See https://github.com/lydell/source-map-url#deprecated"
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",

--- a/src/components/common/ExpensesManager/AddEntry/AddEntry.js
+++ b/src/components/common/ExpensesManager/AddEntry/AddEntry.js
@@ -18,7 +18,7 @@ const getActionFromEntryType = ({ entryType, props }) => {
 class AddEntry extends Component {
   constructor(props) {
     super();
-    this.state = getEntryModel(props.entryType);
+    this.state = getEntryModel({ entryType: props.entryType });
   }
 
   handleInputChange = (event) => {

--- a/src/components/common/ExpensesManager/AddEntry/AddEntry.js
+++ b/src/components/common/ExpensesManager/AddEntry/AddEntry.js
@@ -5,6 +5,7 @@ import { addIncome, addExpense } from '../../../../redux/expensesManager/actionC
 import { getEntryModel, getEntryCategoryOption } from '../../../../helpers/entriesHelper/entriesHelper'; 
 
 import { withRouter } from 'react-router-dom';
+import { getTimestampFromMonthAndYear } from '../../../../helpers/date';
 
 const getActionFromEntryType = ({ entryType, props }) => {
   const entryTypeToActionDictionary = {
@@ -15,10 +16,18 @@ const getActionFromEntryType = ({ entryType, props }) => {
   return entryTypeToActionDictionary[entryType];
 };
 
+// TODO: Change this to a function component instead of a class component
 class AddEntry extends Component {
   constructor(props) {
     super();
-    this.state = getEntryModel({ entryType: props.entryType });
+    this.state = getEntryModel({
+      entryType: props.entryType,
+      // TODO: Make sure the date calculation takes the hours and seconds into account
+      timestamp: getTimestampFromMonthAndYear({
+        month: props.selectedDate.month,
+        year: props.selectedDate.year
+      })
+    });
   }
 
   handleInputChange = (event) => {

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+const toMiliseconds = seconds => seconds * 1000;
 
 const getCurrentYear = () => dayjs().get('year');
 
@@ -6,8 +7,14 @@ const getCurrentMonth = () => dayjs().get('month');
 
 const getMonthNameDisplay = monthNumber => dayjs().month(monthNumber).format('MMMM');
 
+const getCurrentTimestamp = () => toMiliseconds(dayjs().unix());
+
+const getTimestampFromMonthAndYear = ({ month, year }) => toMiliseconds(dayjs().month(month).year(year).unix());
+
 export {
   getCurrentYear,
   getCurrentMonth,
-  getMonthNameDisplay
+  getMonthNameDisplay,
+  getCurrentTimestamp,
+  getTimestampFromMonthAndYear
 };

--- a/src/helpers/entriesHelper/entriesHelper.js
+++ b/src/helpers/entriesHelper/entriesHelper.js
@@ -41,8 +41,7 @@ function getEntries({ entries, entryType }) {
   return entries[entryType];
 }
 
-function getEntryModel(entryType) {
-  const timestamp = dayjs().unix() * 1000;
+function getEntryModel({ entryType, timestamp = dayjs().unix() * 1000 }) {
   return { date: timestamp, amount: '', description: '', type: entryType, categories_path: '' };
 }
 

--- a/src/helpers/entriesHelper/entriesHelper.js
+++ b/src/helpers/entriesHelper/entriesHelper.js
@@ -1,4 +1,5 @@
 import dayjs from "dayjs";
+import { getCurrentTimestamp } from "../date";
 import { calculateTotal } from "../general";
 
 function getSumFromEntries(entries) {
@@ -41,7 +42,7 @@ function getEntries({ entries, entryType }) {
   return entries[entryType];
 }
 
-function getEntryModel({ entryType, timestamp = dayjs().unix() * 1000 }) {
+function getEntryModel({ entryType, timestamp = getCurrentTimestamp() }) {
   return { date: timestamp, amount: '', description: '', type: entryType, categories_path: '' };
 }
 


### PR DESCRIPTION
# Description

A pull request to enable the user to add entries at a different month and year than the current one. It will take the UI into account to do that. The date the user is seeing, is the contextual date where any entry will be saved into the database.

## TODO:

* [ ] Dates might need to be aware of days, hours and seconds for better sorting by date