### PR TITLE
[45] - Temporarily Remove Sign In/Sign up routes #45

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,13 @@
 import React from 'react';
-import { BrowserRouter as Router, Switch, Route, useLocation } from 'react-router-dom';
+import { BrowserRouter as Router, Switch } from 'react-router-dom';
 import Dashboard from './components/Dashboard/Dashboard';
+/**
+ * TODO:
+ * Reinstate <AuthenticatedApp />
+ * https://github.com/users/rivasvict/projects/3/views/1?pane=issue&itemId=75192915
+*/
+// import AuthenticatedApp from './components/AuthenticatedApp';
 import { Provider, connect } from 'react-redux';
-import Lobby from './components/Lobby';
-import SignUp from './components/SignUp/SignUp'
-import PrivateRoute from './components/common/PrivateRoute';
 import { setUser } from './redux/userManager/actoionCreators';
 
 const mapStateToProps = state => ({ user: state.userManager.user });
@@ -13,26 +16,17 @@ const mapActionToProps = dispatch => ({
   onSetUser: () => dispatch(setUser())
 });
 
-const Routes = connect(mapStateToProps, mapActionToProps)(({ user, onSetUser }) => {
-  const PublicRoutes = () => (
-    <>
-      <Route path='/sign-up' component={SignUp} exact />
-      <Route path='/' component={Lobby} exact />
-    </>
-  );
-
-  const location = useLocation();
-  const PrivateRoutes = () => (
-    <>
-      <PrivateRoute path='/dashboard' from={location}>
-        <Dashboard />
-      </PrivateRoute>
-      <PublicRoutes />
-    </>
-  );
-
+const Routes = connect(mapStateToProps, mapActionToProps)(() => {
   return (
-    <PrivateRoutes />
+    <>
+      {/**
+       * TODO:
+       * Reinstate <AuthenticatedApp />
+       * https://github.com/users/rivasvict/projects/3/views/1?pane=issue&itemId=75192915
+      */}
+      {/* <AuthenticatedApp /> */}
+      <Dashboard />
+    </>
   );
 });
 

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -21,21 +21,24 @@ function Dashboard({ entries, selectedDate }) {
       <Container fluid>
         <WorkAreaContentContainer>
           <Switch>
-            <Route path={`${match.url}/add-income`}>
+            <Route path={`${match.url}add-income`}>
               <AddEntry entryType='income' selectedDate={selectedDate} />
             </Route>
-            <Route path={`${match.url}/add-expense`}>
+            <Route path={`${match.url}add-expense`}>
               <AddEntry entryType='expense' selectedDate={selectedDate} />
             </Route>
-            <Route path={`${match.url}/incomes`}>
+            <Route path={`${match.url}incomes`}>
               <EntrySummaryWithFilter selectedDate={selectedDate} entryType='income' />
             </Route>
-            <Route path={`${match.url}/expenses`}>
+            <Route path={`${match.url}expenses`}>
               <EntrySummaryWithFilter selectedDate={selectedDate} entryType='expense' />
             </Route>
-            <Route path={`${match.url}/summary`}>
+            <Route path={`${match.url}summary`}>
               {/* TODO: Fix the issue that appears when the screen is refreshed on the summary route */}
               <Summary entries={entries} selectedDate={selectedDate} />
+            </Route>
+            <Route path={`${match.url}dashboard`}>
+              <DashboardContent {...{ entries, match }} />
             </Route>
             <Route exact path={`${match.url}`}>
               <DashboardContent {...{ entries, match }} />

--- a/src/components/Dashboard/DashboardContent.js
+++ b/src/components/Dashboard/DashboardContent.js
@@ -23,7 +23,7 @@ const handleDateSelectionPointers = ({ entries, selectedDate, onSelectedDateChan
 
 const DashboardContent = ({ entries, match, selectedDate, onSelectedDateChange }) => {
   const monthBalance = (entries[selectedDate.year] && entries[selectedDate.year][selectedDate.month]) || { incomes: [], expenses: [] };
-  const summaryUrl = `${match.url}/summary`;
+  const summaryUrl = `${match.url}summary`;
   const incomesName = 'incomes';
   const expensesName = 'expenses';
   const incomesSum = getSum({ entryType: incomesName, entries: monthBalance })
@@ -70,8 +70,8 @@ const MonthContent = ({ entries, match }) => (
     </Row>
     <Row className='bottom-container'>
       <Col xs={12} className='bottom-content'>
-        <Link to={`${match.url}/add-income`} className='btn btn-primary btn-block'>Add Income</Link>
-        <Link to={`${match.url}/add-expense`} className='btn btn-secondary btn-block'>Add Expenses</Link>
+        <Link to={`${match.url}add-income`} className='btn btn-primary btn-block'>Add Income</Link>
+        <Link to={`${match.url}add-expense`} className='btn btn-secondary btn-block'>Add Expenses</Link>
       </Col>
     </Row>
   </React.Fragment>

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -30,8 +30,8 @@ function Results({ entries, baseUrl = '' }) {
   const expensesName = 'expenses';
   const incomesSum = getSum({ entryType: incomesName, entries })
   const expensesSum = getSum({ entryType: expensesName, entries })
-  const incomesUrl = `${baseUrl}/${incomesName}`;
-  const expensesUrl = `${baseUrl}/${expensesName}`;
+  const incomesUrl = `${baseUrl}${incomesName}`;
+  const expensesUrl = `${baseUrl}${expensesName}`;
 
   return (
     <React.Fragment>

--- a/src/components/common/AuthenticatedApp.tsx
+++ b/src/components/common/AuthenticatedApp.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Route } from "react-router-dom";
+import PrivateRoute from './PrivateRoute';
+import Dashboard from '../Dashboard/Dashboard';
+import SignUp from '../SignUp/SignUp';
+import Lobby from '../Lobby';
+
+const AuthenticatedApp = ({ location }) => {
+  const PublicRoutes = () => (
+    <>
+      <Route path='/sign-up' component={SignUp} exact />
+      <Route path='/' component={Lobby} exact />
+    </>
+  );
+
+  return (
+    <>
+      <PrivateRoute path='/dashboard' from={location}>
+        <Dashboard />
+      </PrivateRoute>
+      <PublicRoutes />
+    </>
+  )
+};
+
+export default AuthenticatedApp;

--- a/src/components/common/ExpensesManager/AddEntry/AddEntry.js
+++ b/src/components/common/ExpensesManager/AddEntry/AddEntry.js
@@ -59,6 +59,7 @@ class AddEntry extends Component {
     }
   }
 
+  /* TODO: Use back history navigation instead of a specific route for cancel action */
   navigateToDashboard = (history) => {
     history.push('/dashboard');
   }
@@ -106,6 +107,7 @@ class AddEntry extends Component {
               <FormButton varian='primary' name='submit' type='submit'>
                 Submit
               </FormButton>
+              {/* TODO: Use back history navigation instead of a specific route for cancel action */}
               <Button block variant='secondary' className='vertical-standard-space' onClick={() => this.navigateToDashboard(this.props.history)}>Cancel</Button>
             </Col>
           </Row>

--- a/src/components/common/ExpensesManager/Summaries/EntrySummaryWithFilter.js
+++ b/src/components/common/ExpensesManager/Summaries/EntrySummaryWithFilter.js
@@ -26,8 +26,8 @@ class EntrySummaryWithFilter extends Component {
   getFilteredEntriesByCategory = ({ category, entryNamePlural }) => {
     const selectedYear = this.selectedDate.year;
     const selectedMonth = this.selectedDate.month;
-    const entries = this.props.entries[selectedYear][selectedMonth][entryNamePlural];
-    return category.length ? entries.filter(entry => entry.categories_path.match(category)) : entries;
+    const entries = this?.props?.entries?.[selectedYear]?.[selectedMonth]?.[entryNamePlural];
+    return category.length ? entries.filter(entry => entry.categories_path.match(category)) : entries || [];
   };
 
   render() {

--- a/src/components/common/ExpensesManager/Summaries/Summary.js
+++ b/src/components/common/ExpensesManager/Summaries/Summary.js
@@ -39,21 +39,21 @@ class Summary extends Component {
   getEntriesToSum = ({ filter = '', props = this.props }) => {
     const datedEntries = this.getDatedEntries({ props });
 
-    return datedEntries[filter] || [...datedEntries['incomes'], ...datedEntries['expenses']];
+    return datedEntries?.[filter] || [...(datedEntries?.['incomes'] || []), ...(datedEntries?.['expenses'] || [])] || [];
   };
 
   getDatedEntries = ({ props = this.props }) => {
     const selectedYear = this.selectedDate.year;
     const selectedMonth = this.selectedDate.month;
     const entries = props.entries;
-    return entries[selectedYear][selectedMonth];
+    return entries?.[selectedYear]?.[selectedMonth] || {incomes: [], expenses: []};
   };
 
   getFilteredEntries = ({ filter = '', props = this.props }) => {
     const datedEntries = this.getDatedEntries({ props });
     const entriesSummary = {
-      incomes: <EntriesSummary entries={datedEntries['incomes']} name='Incomes' selectedDate={this.selectedDate} />,
-      expenses: <EntriesSummary entries={datedEntries['expenses']} name='Expenses' selectedDate={this.selectedDate} />
+      incomes: <EntriesSummary entries={datedEntries?.['incomes']} name='Incomes' selectedDate={this.selectedDate} />,
+      expenses: <EntriesSummary entries={datedEntries?.['expenses']} name='Expenses' selectedDate={this.selectedDate} />
     }
     
     return entriesSummary[filter] ||

--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Col, Container, Navbar, Row } from 'react-bootstrap';
+import { Col, Container, Navbar, Row } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import logoImage from '../../images/expenses_tracker_logo.png';
 import { logOut } from '../../redux/userManager/actoionCreators';
@@ -15,7 +15,12 @@ const Header = ({ onLogOut }) => (
       <Navbar.Toggle aria-controls="basic-navbar-nav" />
       <Navbar.Collapse id="basic-navbar-nav">
         <ButtonLikeLink to='/' buttonTitle='Home' />
-        <Button block type='submit' variant='secondary' onClick={onLogOut}>Sign out</Button>
+        {/**
+         * TODO:
+         * Reinstate <AuthenticatedApp />
+         * https://github.com/users/rivasvict/projects/3/views/1?pane=issue&itemId=75192915
+        */}
+        {/* <Button block type='submit' variant='secondary' onClick={onLogOut}>Sign out</Button> */}
       </Navbar.Collapse>
     </Navbar>
     <Container>


### PR DESCRIPTION
[45 - Temporarily Remove Sign In/Sign up routes #45](https://github.com/rivasvict/react-expenses-manager/issues/45)

This pull request only seeks to make all private routes available by default and all public routes unavailable by default, this means that all of the views of the app should be available now.

* Removed authentication needs for previously private routes.
* Fixed navigation issues with the path (having double `//`).
* Added some guards to prevent broken states.
