### PR TITLE
46

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Dashboard from './components/Dashboard/Dashboard';
 // import AuthenticatedApp from './components/AuthenticatedApp';
 import { Provider, connect } from 'react-redux';
 import { setUser } from './redux/userManager/actoionCreators';
+import WithBalance from './components/WithBalance';
 
 const mapStateToProps = state => ({ user: state.userManager.user });
 
@@ -23,9 +24,17 @@ const Routes = connect(mapStateToProps, mapActionToProps)(() => {
        * TODO:
        * Reinstate <AuthenticatedApp />
        * https://github.com/users/rivasvict/projects/3/views/1?pane=issue&itemId=75192915
+       * 
+       * Additionally, when this code is reinstated, make sure to:
+       * 1. Remove the use of `WithBalance` and its children
+       * 2. In src/redux/expensesManager/actionCreators.js, remember to use the STORAGE_TYPES.REMOTE instead of
+       * STORAGE_TYPES.LOCAL, this will make authentication work again when https://github.com/rivasvict/expenses-manager-api
+       * is configured again
       */}
       {/* <AuthenticatedApp /> */}
-      <Dashboard />
+      <WithBalance>
+        <Dashboard />
+      </WithBalance>
     </>
   );
 });

--- a/src/components/WithBalance/index.js
+++ b/src/components/WithBalance/index.js
@@ -1,0 +1,20 @@
+
+import { connect } from 'react-redux';
+import { getBalance } from '../../redux/expensesManager/actionCreators';
+
+/**
+ *  This is just a component that calls getBalance from redux to set the balance
+ */
+const WithBalance = ({ onGetBalance, children }) => {
+  /** Get/set the balance from redux */
+  onGetBalance();
+  return children;
+};
+
+const mapActionToProps = (dispatch) => ({
+  onGetBalance: () => dispatch(getBalance()),
+});
+
+const mapStateToProps = () => ({});
+
+export default connect(mapStateToProps, mapActionToProps)(WithBalance);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,6 @@
+const STORAGE_TYPES = {
+  LOCAL: 'local',
+  REMOTE: 'remote'
+};
+
+export { STORAGE_TYPES };

--- a/src/redux/expensesManager/actionCreators.js
+++ b/src/redux/expensesManager/actionCreators.js
@@ -1,3 +1,17 @@
 import { ActionCreators } from './actions';
+import storageSelector from '../../services/storageSelector';
+import { STORAGE_TYPES } from '../../constants';
+/**
+ * TODO: Use STORAGE_TYPES.REMOTE
+ * when the connection to the backend is reinstated https://github.com/rivasvict/react-expenses-manager/issues/50
+ */
+const selectedStorage = storageSelector(STORAGE_TYPES.LOCAL);
+const storage = selectedStorage();
 
-export const { addExpense, addIncome, categoryChange, getBalance, setSelectedDate } = ActionCreators();
+export const {
+  addExpense,
+  addIncome,
+  categoryChange,
+  getBalance,
+  setSelectedDate
+} = ActionCreators({ storage });

--- a/src/redux/expensesManager/actions.js
+++ b/src/redux/expensesManager/actions.js
@@ -1,12 +1,9 @@
-import { config } from "../../config";
 import { getGroupedFilledEntriesByDate } from "../../helpers/entriesHelper/entriesHelper";
-import { postConfigAuthenticated } from "../../helpers/general";
 export const ADD_OUTCOME = 'ADD_OUTCOME';
 export const ADD_INCOME = 'ADD_INCOME';
 export const CATEGORY_CHANGE = 'CATEGORY_CHANGE'
 export const GET_BALANCE = 'GET_BALANCE';
 export const SET_SELECTED_DATE = 'SET_SELECTED_DATE';
-const baseUrl = config.REACT_APP_API_HOST
 
 // TODO: AS THIS IS A COMMON ACTION, IT SHOULD
 // LIVE IN ITS OWN FILE
@@ -18,9 +15,9 @@ const setAppLoading = isLoading => ({
   payload: { isLoading: isLoading }
 });
 
-const AddExpense = () => ({ entry, selectedDate }) => setRecord({ entry, type: ADD_OUTCOME, selectedDate });
+const AddExpense = ({ storage }) => ({ entry, selectedDate }) => setRecord({ entry, type: ADD_OUTCOME, selectedDate }, { storage });
 
-const AddIncome = () => ({ entry, selectedDate }) => setRecord({ entry, type: ADD_INCOME, selectedDate });
+const AddIncome = ({ storage }) => ({ entry, selectedDate }) => setRecord({ entry, type: ADD_INCOME, selectedDate }, { storage });
 
 const SetSelectedDate = () => newSelectedDate => ({
   type: SET_SELECTED_DATE,
@@ -32,15 +29,11 @@ const CategoryChange = () => categoryValue => ({
   payload: categoryValue
 });
 
-const GetBalance = () => () => {
+const GetBalance = ({ storage }) => () => {
   return async (dispatch) => {
     try {
-      const url = `${baseUrl}/api/balance`;
       dispatch(setAppLoading(true));
-      const rawResponse = await fetch(url, {
-        credentials: 'include'
-      });
-      const response = await rawResponse.json();
+      const response = await storage.getBalance();
       const fullEntriesWithFilledDates = getGroupedFilledEntriesByDate()(response);
       dispatch({ type: GET_BALANCE, payload: { entries: fullEntriesWithFilledDates }});
       dispatch(setAppLoading(false));
@@ -50,13 +43,11 @@ const GetBalance = () => () => {
   };
 };
 
-const setRecord = ({ entry, type, selectedDate }) => {
+const setRecord = ({ entry, type, selectedDate }, { storage }) => {
   return async (dispatch) => {
     try {
-      const url = `${baseUrl}/api/balance`;
-      const body = JSON.stringify(entry);
       dispatch(setAppLoading(true));
-      await fetch(url, { body, ...postConfigAuthenticated });
+      await storage.setRecord(entry);
       // TODO: Revisit this against the pattern of action creators
       dispatch({ type, payload: { entry, selectedDate } });
       dispatch(setAppLoading(false));
@@ -66,10 +57,12 @@ const setRecord = ({ entry, type, selectedDate }) => {
   }
 };
 
-export const ActionCreators = () => ({
-  addExpense: AddExpense(),
-  addIncome: AddIncome(),
-  categoryChange: CategoryChange(),
-  getBalance: GetBalance(),
-  setSelectedDate: SetSelectedDate()
-});
+export const ActionCreators = ({ storage }) => {
+  return {
+    addExpense: AddExpense({ storage }),
+    addIncome: AddIncome({ storage }),
+    categoryChange: CategoryChange(),
+    getBalance: GetBalance({ storage }),
+    setSelectedDate: SetSelectedDate()
+  }
+};

--- a/src/services/storageSelector/LocalStorage/index.js
+++ b/src/services/storageSelector/LocalStorage/index.js
@@ -1,0 +1,18 @@
+const BALANCE = 'balance';
+
+const getBalanceFromLocalStorage = () => {
+  const storedBalance = localStorage.getItem(BALANCE) || '';
+  return storedBalance ? JSON.parse(storedBalance) : [];
+};
+
+const LocalStorage = () => ({
+  getBalance: () => getBalanceFromLocalStorage(),
+  setRecord: (entry) => {
+    if (!entry) throw new Error('No entry was added');
+    const balance = getBalanceFromLocalStorage();
+    const newBalance = [...balance, entry];
+    localStorage.setItem(BALANCE, JSON.stringify(newBalance));
+  }
+});
+
+export default LocalStorage;

--- a/src/services/storageSelector/RemoteStorage/index.js
+++ b/src/services/storageSelector/RemoteStorage/index.js
@@ -1,0 +1,28 @@
+import { config } from "../../../config";
+import { postConfigAuthenticated } from "../../../helpers/general";
+const baseUrl = config.REACT_APP_API_HOST
+
+const HttpStorage = () => ({
+  getBalance: async () => {
+    try {
+      const url = `${baseUrl}/api/balance`;
+      const rawResponse = await fetch(url, {
+        credentials: 'include'
+      });
+      return await rawResponse.json();
+    } catch (error) {
+      console.log(error);
+    }
+  }, 
+  setRecord: async (entry) => {
+    try {
+      const url = `${baseUrl}/api/balance`;
+      const body = JSON.stringify(entry);
+      await fetch(url, { body, ...postConfigAuthenticated });
+    } catch (error) {
+      console.log(error);
+    }
+  }
+});
+
+export default HttpStorage;

--- a/src/services/storageSelector/index.js
+++ b/src/services/storageSelector/index.js
@@ -1,0 +1,16 @@
+import RemoteStorage from "./RemoteStorage";
+import LocalStorage from "./LocalStorage";
+import { STORAGE_TYPES } from "../../constants";
+
+const storageSelector = (storageType) => {
+  const storageMap = {
+    [STORAGE_TYPES.LOCAL]: LocalStorage,
+    [STORAGE_TYPES.REMOTE]: RemoteStorage
+  };
+
+  const selectedStorage = storageMap[storageType];
+  // If no storageType is pased , then default to local;
+  return selectedStorage ?? storageMap[STORAGE_TYPES.LOCAL];
+}
+
+export default storageSelector;


### PR DESCRIPTION
[46 - Make sure adding income/expenses work without session](https://github.com/rivasvict/react-expenses-manager/issues/46)

What was done:

1. Abstracted the storage into `local` and `remote`
2. Introduced a `storageSelector`
3. LocalStorage will use localStorage to store the data and RemoteStorage (temporarily deactivated) will store the data in our db