### PR TITLE
70 1 - Add entry deletion capabilities

### DIFF
--- a/src/components/common/ExpensesManager/AddEntry/index.js
+++ b/src/components/common/ExpensesManager/AddEntry/index.js
@@ -37,9 +37,8 @@ const AddEntry = ({
     }),
   });
 
-  /* TODO: Use back history navigation instead of a specific route for cancel action */
-  const navigateToDashboard = () => {
-    history.push("/dashboard");
+  const navigateBack = () => {
+    history.goBack();
   };
 
   const handleEntry = getActionFromEntryType({
@@ -58,7 +57,7 @@ const AddEntry = ({
     // TODO: review the validation for the missing category
     if (amount && digitMatcher.test(amount) && entry.categories_path !== "") {
       handleEntry({ entry, selectedDate });
-      navigateToDashboard();
+      navigateBack();
     }
   };
 
@@ -67,7 +66,7 @@ const AddEntry = ({
       entry={newEntry}
       selectedDate={selectedDate}
       handleSubmit={handleSubmit}
-      onCancel={navigateToDashboard}
+      onCancel={navigateBack}
       operationTitle={ADD_NEW}
     />
   );

--- a/src/components/common/ExpensesManager/AddEntry/index.js
+++ b/src/components/common/ExpensesManager/AddEntry/index.js
@@ -8,6 +8,8 @@ import {
   addIncome,
 } from "../../../../redux/expensesManager/actionCreators";
 
+const ADD_NEW = "Add new";
+
 const getActionFromEntryType = ({ entryType, actions }) => {
   const entryTypeToActionDictionary = {
     income: actions["onAddIncome"],
@@ -66,6 +68,7 @@ const AddEntry = ({
       selectedDate={selectedDate}
       handleSubmit={handleSubmit}
       onCancel={navigateToDashboard}
+      operationTitle={ADD_NEW}
     />
   );
 };

--- a/src/components/common/ExpensesManager/EditEntry/index.js
+++ b/src/components/common/ExpensesManager/EditEntry/index.js
@@ -3,7 +3,7 @@ import EntryForm from "../EntryForm";
 import {
   getEntryById,
   editEntry,
-  // removeEntry,
+  removeEntry,
 } from "../../../../redux/expensesManager/actionCreators";
 import { connect } from "react-redux";
 import { useEffect, useState } from "react";
@@ -12,9 +12,10 @@ import { withRouter } from "react-router-dom";
 const EditEntry = ({
   entryType,
   selectedDate,
-  onGetEntry,
   history,
+  onGetEntry,
   onSaveEntry,
+  onRemoveEntry,
 }) => {
   const params = useParams();
   const { entryId } = params;
@@ -47,12 +48,19 @@ const EditEntry = ({
     }
   };
 
+  const handleEntryRemoval = ({ entryId }) => {
+    onRemoveEntry({ entryId });
+    // TODO: Try using back navigation instead
+    navigateToDashboard();
+  };
+
   return entry ? (
     <EntryForm
       entry={entry}
       selectedDate={selectedDate}
       type={entryType}
       handleSubmit={handleSubmit}
+      handleEntryRemoval={handleEntryRemoval}
     />
   ) : (
     <>Entry not found</>
@@ -66,7 +74,7 @@ const mapStateToProps = (state) => ({
 const mapActionsToProps = (dispatch) => ({
   onGetEntry: (entryId) => dispatch(getEntryById(entryId)),
   onSaveEntry: ({ entryId, entry }) => dispatch(editEntry({ entryId, entry })),
-  // onRemoveEntry: (entryId) => dispatch(removeEntry(entryId)),
+  onRemoveEntry: (entryId) => dispatch(removeEntry(entryId)),
 });
 
 export default connect(

--- a/src/components/common/ExpensesManager/EditEntry/index.js
+++ b/src/components/common/ExpensesManager/EditEntry/index.js
@@ -9,6 +9,7 @@ import { connect } from "react-redux";
 import { useEffect, useState } from "react";
 import { withRouter } from "react-router-dom";
 
+const EDIT = "Edit";
 const EditEntry = ({
   entryType,
   selectedDate,
@@ -61,6 +62,7 @@ const EditEntry = ({
       type={entryType}
       handleSubmit={handleSubmit}
       handleEntryRemoval={handleEntryRemoval}
+      operationTitle={EDIT}
     />
   ) : (
     <>Entry not found</>

--- a/src/components/common/ExpensesManager/EditEntry/index.js
+++ b/src/components/common/ExpensesManager/EditEntry/index.js
@@ -27,14 +27,8 @@ const EditEntry = ({
       setEntry(entryToDisplay);
     })();
   }, [entryId, onGetEntry]);
-  /**
-   * Next steps:
-   * 4. Add a callback handler for the submit action
-   * 5. Add the deletion flow (including button and callback)
-   */
-  /* TODO: Use back history navigation instead of a specific route for cancel action */
-  const navigateToDashboard = () => {
-    history.push("/dashboard");
+  const navigateBack = () => {
+    history.goBack();
   };
 
   const handleSubmit = (event, { entryToAdd }) => {
@@ -45,14 +39,14 @@ const EditEntry = ({
     // TODO: review the validation for the missing category
     if (amount && digitMatcher.test(amount) && entry.categories_path !== "") {
       onSaveEntry({ entry });
-      navigateToDashboard();
+      navigateBack();
     }
   };
 
   const handleEntryRemoval = ({ entryId }) => {
     onRemoveEntry({ entryId });
     // TODO: Try using back navigation instead
-    navigateToDashboard();
+    navigateBack();
   };
 
   return entry ? (
@@ -63,6 +57,7 @@ const EditEntry = ({
       handleSubmit={handleSubmit}
       handleEntryRemoval={handleEntryRemoval}
       operationTitle={EDIT}
+      onCancel={navigateBack}
     />
   ) : (
     <>Entry not found</>

--- a/src/components/common/ExpensesManager/EntryForm/index.js
+++ b/src/components/common/ExpensesManager/EntryForm/index.js
@@ -78,7 +78,22 @@ class EntryForm extends Component {
           </Row>
           <Row className="bottom-container container-fluid vertical-standard-space">
             <Col xs={12} className="bottom-content">
-              <FormButton variant="primary" name="submit" type="submit">
+              {this.props.handleEntryRemoval && (
+                <Button
+                  variant="danger"
+                  onClick={() =>
+                    this.props.handleEntryRemoval({ entryId: this.state.id })
+                  }
+                >
+                  REMOVE ENTRY
+                </Button>
+              )}
+              <FormButton
+                variant="primary"
+                name="submit"
+                type="submit"
+                className="vertical-standard-space"
+              >
                 Submit
               </FormButton>
               <Button

--- a/src/components/common/ExpensesManager/EntryForm/index.js
+++ b/src/components/common/ExpensesManager/EntryForm/index.js
@@ -29,11 +29,14 @@ class EntryForm extends Component {
 
   render() {
     const categoryOptions = getEntryCategoryOption(this.state.type);
+    const operationTitle = this.props.operationTitle
+      ? `${this.props.operationTitle} `
+      : "";
 
     return (
       <MainContentContainer>
         <ContentTileSection>
-          Add new {capitalize(this.props.type)}
+          {`${operationTitle}${capitalize(this.state.type)}`}
         </ContentTileSection>
         <FormContent
           formProps={{

--- a/src/components/common/ExpensesManager/Summaries/Summary/index.js
+++ b/src/components/common/ExpensesManager/Summaries/Summary/index.js
@@ -15,7 +15,10 @@ import { getMonthNameDisplay } from "../../../../../helpers/date";
 import "./styles.scss";
 import SummaryChart from "./components/SummaryChart";
 import SummaryWithChart from "../../../SummaryWithChart";
-import { ENTRY_TYPES_PLURAL } from "../../../../../constants";
+import {
+  ENTRY_TYPES_PLURAL,
+  ENTRY_TYPES_SINGULAR,
+} from "../../../../../constants";
 import ChartContainerRowWrapper from "../../../ChartContainerRowWrapper";
 
 /**
@@ -81,11 +84,13 @@ class Summary extends Component {
           entries={datedEntries?.[ENTRY_TYPES_PLURAL.INCOMES]}
           name={capitalize(ENTRY_TYPES_PLURAL.INCOMES)}
           showChart={!!filter}
+          entryType={ENTRY_TYPES_SINGULAR.INCOME}
         />
       ) : (
         <EntriesSummary
           entries={datedEntries?.[ENTRY_TYPES_PLURAL.INCOMES]}
           name={ENTRY_TYPES_PLURAL.INCOMES}
+          entryType={ENTRY_TYPES_SINGULAR.INCOME}
         />
       ),
       expenses: !!filter ? (
@@ -93,11 +98,13 @@ class Summary extends Component {
           entries={datedEntries?.[ENTRY_TYPES_PLURAL.EXPENSES]}
           name={capitalize(ENTRY_TYPES_PLURAL.EXPENSES)}
           showChart={!!filter}
+          entryType={ENTRY_TYPES_SINGULAR.EXPENSE}
         />
       ) : (
         <EntriesSummary
           entries={datedEntries?.[ENTRY_TYPES_PLURAL.EXPENSES]}
           name={capitalize(ENTRY_TYPES_PLURAL.EXPENSES)}
+          entryType={ENTRY_TYPES_SINGULAR.EXPENSE}
         />
       ),
     };

--- a/src/redux/expensesManager/actionCreators.js
+++ b/src/redux/expensesManager/actionCreators.js
@@ -16,4 +16,5 @@ export const {
   setSelectedDate,
   getEntryById,
   editEntry,
+  removeEntry,
 } = ActionCreators({ storage });

--- a/src/redux/expensesManager/actions.js
+++ b/src/redux/expensesManager/actions.js
@@ -5,6 +5,7 @@ export const CATEGORY_CHANGE = "CATEGORY_CHANGE";
 export const GET_BALANCE = "GET_BALANCE";
 export const SET_SELECTED_DATE = "SET_SELECTED_DATE";
 export const EDIT_ENTRY = "EDIT_ENTRY";
+export const REMOVE_ENTRY = "REMOVE_ENTRY";
 
 // TODO: AS THIS IS A COMMON ACTION, IT SHOULD
 // LIVE IN ITS OWN FILE
@@ -101,6 +102,22 @@ const EditEntry =
     };
   };
 
+const RemoveEntry =
+  ({ storage }) =>
+  ({ entryId }) => {
+    return async (dispatch) => {
+      try {
+        dispatch(setAppLoading(true));
+        const newBalance = await storage.removeEntry({ entryId });
+        const entries = getGroupedFilledEntriesByDate()(newBalance);
+        dispatch({ type: REMOVE_ENTRY, payload: { entries } });
+        dispatch(setAppLoading(false));
+      } catch (error) {
+        console.log(error);
+      }
+    };
+  };
+
 export const ActionCreators = ({ storage }) => {
   return {
     addExpense: AddExpense({ storage }),
@@ -110,5 +127,6 @@ export const ActionCreators = ({ storage }) => {
     setSelectedDate: SetSelectedDate(),
     getEntryById: GetEntryById({ storage }),
     editEntry: EditEntry({ storage }),
+    removeEntry: RemoveEntry({ storage }),
   };
 };

--- a/src/redux/expensesManager/reducer.js
+++ b/src/redux/expensesManager/reducer.js
@@ -8,6 +8,7 @@ import {
   GET_BALANCE,
   SET_SELECTED_DATE,
   EDIT_ENTRY,
+  REMOVE_ENTRY,
 } from "./actions";
 
 const initialState = {
@@ -91,6 +92,14 @@ export const reducer = (state = initialState, action) => {
         currentState: state,
       });
     case EDIT_ENTRY:
+      return {
+        ...state,
+        entries: {
+          ...state.entries,
+          ...payload.entries,
+        },
+      };
+    case REMOVE_ENTRY:
       return {
         ...state,
         entries: {

--- a/src/services/storageSelector/LocalStorage/index.js
+++ b/src/services/storageSelector/LocalStorage/index.js
@@ -35,6 +35,14 @@ const LocalStorage = () => ({
     storeBalance(newBalance);
     return newBalance;
   },
+  removeEntry: ({ entryId }) => {
+    const balance = getBalanceFromLocalStorage();
+    const newBalance = balance.filter(
+      (originalEntry) => originalEntry.id !== entryId
+    );
+    storeBalance(newBalance);
+    return newBalance;
+  },
 });
 
 export default LocalStorage;


### PR DESCRIPTION
This is a continuation of https://github.com/rivasvict/react-expenses-manager/pull/75 trying to separate.

## Description

* Adds the deletion capabilities for entries
* Solves some bugs:
  * Name title of summaries for entry types
  * Cancel action on enties manipulation