### PR TITLE
[Fix #93] Remove unused empty months — disable Prev navigation when no data

### DIFF
--- a/src/helpers/entriesHelper/entriesHelper.js
+++ b/src/helpers/entriesHelper/entriesHelper.js
@@ -314,10 +314,13 @@ const getEntriesWithFilledDates =
  * @param {Arrat<Objec>} entries - Array of entries
  */
 const getGroupedFilledEntriesByDate = () => (entries) => {
+  if (!entries.length) {
+    return getCurrentEmptyMonth();
+  }
   const groupedEntriesByDate = getGroupEntriesByDate()(entries);
   return getEntriesWithFilledDates()({
     entries: groupedEntriesByDate,
-    firstEntryDate: entries.length && entries[0].date,
+    firstEntryDate: entries[0].date,
   });
 };
 

--- a/src/integrationTests/navigation.test.tsx
+++ b/src/integrationTests/navigation.test.tsx
@@ -15,6 +15,15 @@ afterEach(() => {
 });
 
 describe("navigation", () => {
+  it("does not show a Prev button when there is no data", async () => {
+    // localStorage has no entries — the app should show only the current month
+    // with no possibility to navigate to previous months
+    await renderApp("/");
+
+    await screen.findByText("May 2026");
+    expect(screen.queryByRole("button", { name: /prev/i })).not.toBeInTheDocument();
+  });
+
   it("shows the current month (May 2026) when opening the app", async () => {
     seedEntries([
       { date: ts(2026, MAY), amount: "100", type: "income", categories_path: ",salary," },


### PR DESCRIPTION
## Issue

#93 

## Summary

- **Root cause:** `getGroupedFilledEntriesByDate` passed `entries.length && entries[0].date` as `firstEntryDate`. When `entries` is empty, this evaluates to `0` (not `false`), so `dayjs(0)` resolved to epoch (1970-01-01) and `getEntriesWithFilledDates` filled every month from 1970 to now — making the Prev button available with no real data.
- **Fix:** Short-circuit in `getGroupedFilledEntriesByDate` to return `getCurrentEmptyMonth()` directly when the entries array is empty, so only the current month exists and navigation is disabled.
- **Bug 2 (from the issue):** Adding an entry on a phantom previous month then seeing it move to the current month after refresh is automatically resolved by the same fix — those phantom months no longer exist.

## Test plan

- [ ] New regression test `"does not show a Prev button when there is no data"` passes (confirms the fix).
- [ ] All existing navigation integration tests still pass (confirms no regression in real-data navigation).
- [ ] Pre-existing failures in `entriesHelper.test.js` (unrelated to this change — failing before this PR) are unchanged.

https://claude.ai/code/session_012paau4FKCSijBgV1puShkU

---
_Generated by [Claude Code](https://claude.ai/code/session_012paau4FKCSijBgV1puShkU)_