### PR TITLE
feat(buckets): per-month limit edits apply forward from the edited month (issue #102)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,12 @@ Node version is pinned in `.nvmrc`.
 - Categories are hardcoded in `src/helpers/entriesHelper/entriesHelper.js` (`getEntryCategoryOption`) and must match the bucket names in the reducer's `initialState`
 - Mixed JS/TS: existing JS files stay `.js`; new components use `.tsx`. TypeScript errors in JSX are sometimes suppressed with `{/* @ts-expect-error */}` or `{/** @ts-ignore */}`
 
+## Integration test helpers (`src/integrationTests/helpers/`)
+
+- **`renderApp.tsx`** — renders the full app in a `MemoryRouter` with a fresh Redux store; returns `{ user, store, ...RenderResult }`.
+- **`seed.ts`** — `seedEntries(entries)` writes entries to `localStorage`; `ts(year, month, day?)` builds a Unix-ms timestamp; month constants `JANUARY`–`DECEMBER` (0-indexed).
+- **`navigation.ts`** — `goToPrevMonth(user, expectedTitle)` and `goToNextMonth(user, expectedTitle)`: click the Prev/Next button and wait for the new month heading. Use these instead of inline `findByRole("button", …)` calls so the assertion pattern stays consistent across test files.
+
 ## General guidelines for development
 
 * Make sure to run `npm test -- --testPathPattern="integrationTests"` on every edition such that we make sure no functionality is broken.

--- a/src/components/common/ExpensesManager/Buckets/components/Bucket/index.tsx
+++ b/src/components/common/ExpensesManager/Buckets/components/Bucket/index.tsx
@@ -40,6 +40,7 @@ const Bucket = ({
       <RowLink
         to={`edit-bucket/${category.toLowerCase().replace(/\s/g, "-")}`}
         title={`Edit ${category}`}
+        aria-label={`Edit ${category}`}
         className="bucket-container"
         data-testid={testId}
       >

--- a/src/components/common/ExpensesManager/Buckets/index.tsx
+++ b/src/components/common/ExpensesManager/Buckets/index.tsx
@@ -56,7 +56,7 @@ const Buckets = ({ selectedDate, entries, history, buckets }) => {
     });
 
   const totalBucketAllocation = Object.keys(buckets).reduce(
-    (sum, bucketName) => buckets[bucketName] + sum,
+    (sum, bucketName) => (carriedBuckets[bucketName]?.allowance ?? 0) + sum,
     0
   );
 

--- a/src/components/common/ExpensesManager/EditBucket/EditBucket.tsx
+++ b/src/components/common/ExpensesManager/EditBucket/EditBucket.tsx
@@ -9,32 +9,26 @@ import {
 } from "../../../../redux/expensesManager/actionCreators";
 import { FormButton, FormContent, InputNumber } from "../../Forms";
 import { Col, Form, Row, Button } from "react-bootstrap";
+import { getActiveLimitForMonth, toYearMonth } from "../../../../helpers/entriesHelper/entriesHelper";
 
-const EditBucket = ({ onGetBucket, onEditBucket, history }) => {
+const EditBucket = ({ onGetBucket, onEditBucket, history, selectedDate }) => {
   const params = useParams();
   const { bucketName } = params;
   const [bucket, setBucket] = useState({ name: "", value: 0 });
 
   useEffect(() => {
     (async () => {
-      /**
-       * TODO: Define central expected type from the database
-       */
-      const bucketFromDb: Record<string, number> = await onGetBucket({
-        bucketName,
-      });
-      /**
-       * TODO: Temporary way to extract the value and name of the bucket
-       * while I find a better way to structure buckets in the database
-       **/
-      const [name, value] = Object.entries(bucketFromDb)[0];
+      const bucketFromDb = await onGetBucket({ bucketName });
+      const [name, history] = Object.entries(bucketFromDb)[0] as [string, any];
+      const yearMonth = toYearMonth(selectedDate.year, selectedDate.month);
+      const value = getActiveLimitForMonth(history, yearMonth);
       setBucket({ name, value });
     })();
-  }, [bucketName, onGetBucket]);
+  }, [bucketName, onGetBucket, selectedDate]);
 
   const saveBucket = async (editedBucketValue) => {
     try {
-      await onEditBucket({ bucket: editedBucketValue });
+      await onEditBucket({ bucket: editedBucketValue, selectedDate });
     } catch (error) {
       throw error;
     }
@@ -69,8 +63,12 @@ const EditBucket = ({ onGetBucket, onEditBucket, history }) => {
                       value={bucket?.value}
                       onChange={(event) => {
                         const value = event?.currentTarget?.value;
+                        if (!value) {
+                          setBucket({ name: bucket?.name, value: 0 });
+                          return;
+                        }
                         const digitMatcher = /^\d*(\.)*\d+$/;
-                        if (value && digitMatcher.test(value)) {
+                        if (digitMatcher.test(value)) {
                           setBucket({
                             name: bucket?.name,
                             value: parseFloat(value),
@@ -108,12 +106,17 @@ const EditBucket = ({ onGetBucket, onEditBucket, history }) => {
   );
 };
 
+const mapStateToProps = (state) => ({
+  selectedDate: state.expensesManager.selectedDate,
+});
+
 const mapActionsToProps = (dispatch) => ({
   onGetBucket: ({ bucketName }) => dispatch(getBucket({ bucketName })),
-  onEditBucket: ({ bucket }) => dispatch(editBucket({ bucket })),
+  onEditBucket: ({ bucket, selectedDate }) =>
+    dispatch(editBucket({ bucket, selectedDate })),
 });
 
 export default connect(
-  mapActionsToProps,
+  mapStateToProps,
   mapActionsToProps
 )(withRouter(EditBucket));

--- a/src/components/common/ExpensesManager/EditBucket/EditBucket.tsx
+++ b/src/components/common/ExpensesManager/EditBucket/EditBucket.tsx
@@ -14,7 +14,7 @@ import { getActiveLimitForMonth, toYearMonth } from "../../../../helpers/entries
 const EditBucket = ({ onGetBucket, onEditBucket, history, selectedDate }) => {
   const params = useParams();
   const { bucketName } = params;
-  const [bucket, setBucket] = useState({ name: "", value: 0 });
+  const [bucket, setBucket] = useState<{ name: string; value: number | "" }>({ name: "", value: 0 });
 
   useEffect(() => {
     (async () => {
@@ -48,7 +48,7 @@ const EditBucket = ({ onGetBucket, onEditBucket, history, selectedDate }) => {
         formProps={{
           onSubmit: (event) => {
             event.preventDefault();
-            const editedBucket = { [bucket.name]: bucket.value };
+            const editedBucket = { [bucket.name]: Number(bucket.value) };
             saveBucket(editedBucket);
             history.goBack();
           },
@@ -68,7 +68,7 @@ const EditBucket = ({ onGetBucket, onEditBucket, history, selectedDate }) => {
                       onChange={(event) => {
                         const value = event?.currentTarget?.value;
                         if (!value) {
-                          setBucket({ name: bucket?.name, value: 0 });
+                          setBucket({ name: bucket?.name, value: "" });
                           return;
                         }
                         const digitMatcher = /^\d*(\.)*\d+$/;

--- a/src/components/common/ExpensesManager/EditBucket/EditBucket.tsx
+++ b/src/components/common/ExpensesManager/EditBucket/EditBucket.tsx
@@ -18,10 +18,14 @@ const EditBucket = ({ onGetBucket, onEditBucket, history, selectedDate }) => {
 
   useEffect(() => {
     (async () => {
-      const bucketFromDb = await onGetBucket({ bucketName });
-      const [name, history] = Object.entries(bucketFromDb)[0] as [string, any];
+      const bucketFromDb: Record<string, number | Array<{ from: string; limit: number }>> =
+        await onGetBucket({ bucketName });
+      const [name, bucketsHistory] = Object.entries(bucketFromDb)[0] as [
+        string,
+        number | Array<{ from: string; limit: number }>
+      ];
       const yearMonth = toYearMonth(selectedDate.year, selectedDate.month);
-      const value = getActiveLimitForMonth(history, yearMonth);
+      const value = getActiveLimitForMonth(bucketsHistory, yearMonth);
       setBucket({ name, value });
     })();
   }, [bucketName, onGetBucket, selectedDate]);

--- a/src/helpers/entriesHelper/entriesHelper.js
+++ b/src/helpers/entriesHelper/entriesHelper.js
@@ -439,6 +439,41 @@ const getGroupedFilledEntriesByDate = () => (entries) => {
 };
 
 /**
+ * Converts a 0-indexed month + year to an ISO-style "YYYY-MM" string used as
+ * the `from` key in the per-month bucket limit history.
+ *
+ * @param {number} year
+ * @param {number} month - 0-indexed (0 = January, 11 = December)
+ * @returns {string} e.g. "2026-03"
+ */
+const toYearMonth = (year, month) =>
+  `${year}-${String(month + 1).padStart(2, "0")}`;
+
+/**
+ * Resolves the effective spending limit for a bucket in a given month.
+ *
+ * Bucket values in storage can be:
+ *   - a plain number (old format, backward-compatible) — returned as-is.
+ *   - an array of `{ from: "YYYY-MM", limit: number }` entries (new format) —
+ *     the most recent entry whose `from` <= `yearMonth` is used.
+ *
+ * If no entry is <= yearMonth (i.e. the bucket was created after the requested
+ * month), the oldest entry's limit is returned so the bucket still has a
+ * sensible value.
+ *
+ * @param {number|Array<{from: string, limit: number}>} bucketValue
+ * @param {string} yearMonth - "YYYY-MM" (1-indexed month)
+ * @returns {number}
+ */
+const getActiveLimitForMonth = (bucketValue, yearMonth) => {
+  if (typeof bucketValue === "number") return bucketValue;
+  if (!Array.isArray(bucketValue) || bucketValue.length === 0) return 0;
+  const sorted = [...bucketValue].sort((a, b) => (a.from > b.from ? -1 : 1));
+  const active = sorted.find((entry) => entry.from <= yearMonth);
+  return active ? active.limit : sorted[sorted.length - 1].limit;
+};
+
+/**
  * Sums the expense amounts of a single month grouped by bucket.
  *
  * Spending for a bucket is the accumulated amount of every expense whose
@@ -529,8 +564,10 @@ const getCarriedBucketsForMonth = ({ entries, buckets, selectedDate }) => {
     return accumulatedRemainders;
   }, {});
 
+  // Initial state (used when there are no recorded months to walk through).
+  const selectedYearMonth = toYearMonth(selectedDate.year, selectedDate.month);
   const carriedBuckets = bucketNames.reduce((carried, bucketName) => {
-    const allowance = buckets[bucketName];
+    const allowance = getActiveLimitForMonth(buckets[bucketName], selectedYearMonth);
     carried[bucketName] = {
       allowance,
       carryOver: 0,
@@ -542,13 +579,14 @@ const getCarriedBucketsForMonth = ({ entries, buckets, selectedDate }) => {
   }, {});
 
   for (const { year, month } of recordedMonths) {
+    const yearMonth = toYearMonth(year, month);
     const expenses = entries?.[year]?.[month]?.expenses || [];
     const spendingByBucket = getMonthSpendingByBucket({ expenses, bucketNames });
     const isSelectedMonth =
       year === selectedDate.year && month === selectedDate.month;
 
     bucketNames.forEach((bucketName) => {
-      const allowance = buckets[bucketName];
+      const allowance = getActiveLimitForMonth(buckets[bucketName], yearMonth);
       const carryOver = remainders[bucketName];
       const availability = allowance + carryOver;
       const spending = spendingByBucket[bucketName];
@@ -608,4 +646,6 @@ export {
   getMonthSpendingByBucket,
   getRecordedMonthsUntil,
   getCarriedBucketsForMonth,
+  toYearMonth,
+  getActiveLimitForMonth,
 };

--- a/src/integrationTests/bucketLimitEdits.test.tsx
+++ b/src/integrationTests/bucketLimitEdits.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import { renderApp } from "./helpers/renderApp";
 import { seedEntries, ts, JANUARY, FEBRUARY, MARCH, APRIL, MAY } from "./helpers/seed";
+import { goToPrevMonth, goToNextMonth } from "./helpers/navigation";
 
 // Pinned to May 2026 so we can navigate from May back through earlier months.
 const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
@@ -14,22 +15,6 @@ beforeEach(() => {
 afterEach(() => {
   jest.useRealTimers();
 });
-
-async function goToPrevMonth(
-  user: Awaited<ReturnType<typeof renderApp>>["user"],
-  expectedTitle: string
-) {
-  await user.click(await screen.findByRole("button", { name: /prev/i }));
-  await screen.findByText(expectedTitle);
-}
-
-async function goToNextMonth(
-  user: Awaited<ReturnType<typeof renderApp>>["user"],
-  expectedTitle: string
-) {
-  await user.click(await screen.findByRole("button", { name: /next/i }));
-  await screen.findByText(expectedTitle);
-}
 
 function bucketAvailability(testIdBase: string): string {
   return screen.getByTestId(`${testIdBase}-availability`).textContent as string;

--- a/src/integrationTests/bucketLimitEdits.test.tsx
+++ b/src/integrationTests/bucketLimitEdits.test.tsx
@@ -1,0 +1,225 @@
+import { screen } from "@testing-library/react";
+import { renderApp } from "./helpers/renderApp";
+import { seedEntries, ts, JANUARY, FEBRUARY, MARCH, APRIL, MAY } from "./helpers/seed";
+
+// Pinned to May 2026 so we can navigate from May back through earlier months.
+const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.useFakeTimers();
+  jest.setSystemTime(PINNED_DATE);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+async function goToPrevMonth(
+  user: Awaited<ReturnType<typeof renderApp>>["user"],
+  expectedTitle: string
+) {
+  await user.click(await screen.findByRole("button", { name: /prev/i }));
+  await screen.findByText(expectedTitle);
+}
+
+async function goToNextMonth(
+  user: Awaited<ReturnType<typeof renderApp>>["user"],
+  expectedTitle: string
+) {
+  await user.click(await screen.findByRole("button", { name: /next/i }));
+  await screen.findByText(expectedTitle);
+}
+
+function bucketAvailability(testIdBase: string): string {
+  return screen.getByTestId(`${testIdBase}-availability`).textContent as string;
+}
+
+function bucketCarryOver(testIdBase: string): string {
+  return screen.getByTestId(`${testIdBase}-carry-over`).textContent as string;
+}
+
+describe("per-month bucket limit edits (issue #102)", () => {
+  it("old-format (number) buckets continue to work unchanged", async () => {
+    // Seed the old flat format to verify backward compatibility.
+    localStorage.setItem("buckets", JSON.stringify({ Food: 200 }));
+    seedEntries([
+      { date: ts(2026, JANUARY), amount: "50", type: "expense", categories_path: ",food," },
+    ]);
+
+    const { user } = await renderApp("/buckets");
+    await screen.findByText("May 2026");
+    await goToPrevMonth(user, "April 2026");
+    await goToPrevMonth(user, "March 2026");
+    await goToPrevMonth(user, "February 2026");
+    await goToPrevMonth(user, "January 2026");
+
+    expect(bucketAvailability("bucket-food")).toBe("$200.00");
+  });
+
+  it("new-format buckets display the effective limit for each month", async () => {
+    // Simulate a history where the limit changed in March and again in May.
+    localStorage.setItem(
+      "buckets",
+      JSON.stringify({
+        Food: [
+          { from: "0000-00", limit: 200 },
+          { from: "2026-03", limit: 300 },
+          { from: "2026-05", limit: 150 },
+        ],
+      })
+    );
+    // Seed a dummy entry in January so the entries tree spans Jan–May and the
+    // Prev navigation button becomes available.
+    seedEntries([
+      { date: ts(2026, JANUARY), amount: "100", type: "income", categories_path: ",salary," },
+    ]);
+
+    const { user } = await renderApp("/buckets");
+    await screen.findByText("May 2026");
+
+    // May: effective limit is 150 (most recent entry).
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$150\.00/);
+
+    await goToPrevMonth(user, "April 2026");
+    // April: limit 300 (applied from March).
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$300\.00/);
+
+    await goToPrevMonth(user, "March 2026");
+    // March: limit 300 (first month of that edit).
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$300\.00/);
+
+    await goToPrevMonth(user, "February 2026");
+    // February: limit 200 (original).
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$200\.00/);
+
+    await goToPrevMonth(user, "January 2026");
+    // January: limit 200 (original).
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$200\.00/);
+  });
+
+  it("editing a bucket while viewing March applies the new limit from March forward", async () => {
+    localStorage.setItem(
+      "buckets",
+      JSON.stringify({ Food: [{ from: "0000-00", limit: 200 }] })
+    );
+    // Dummy entry in January so the entries tree spans Jan–May and navigation
+    // buttons are available.
+    seedEntries([
+      { date: ts(2026, JANUARY), amount: "100", type: "income", categories_path: ",salary," },
+    ]);
+
+    const { user } = await renderApp("/buckets");
+    await screen.findByText("May 2026");
+
+    // Navigate to March to make that the selected month.
+    await goToPrevMonth(user, "April 2026");
+    await goToPrevMonth(user, "March 2026");
+    await screen.findByText("March 2026");
+
+    // Click the Food bucket row to go to the edit page.
+    await user.click(await screen.findByRole("link", { name: /edit food/i }));
+    await screen.findByText(/edit bucket: food/i);
+
+    // Clear the current value and type the new limit.
+    const input = screen.getByPlaceholderText(/insert bucket amount/i);
+    await user.clear(input);
+    await user.type(input, "300");
+    await user.click(screen.getByRole("button", { name: /submit/i }));
+
+    // Redirected back to the buckets page (March is still selected).
+    await screen.findByText("March 2026");
+    // March: limit is now 300.
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$300\.00/);
+
+    // April: limit carries forward as 300.
+    await goToNextMonth(user, "April 2026");
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$300\.00/);
+
+    // May: limit still 300.
+    await goToNextMonth(user, "May 2026");
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$300\.00/);
+
+    // Navigate back to January: limit is still 200 (edit did not go backward).
+    await goToPrevMonth(user, "April 2026");
+    await goToPrevMonth(user, "March 2026");
+    await goToPrevMonth(user, "February 2026");
+    await goToPrevMonth(user, "January 2026");
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$200\.00/);
+  });
+
+  it("editing a bucket limit in May does not affect April or earlier", async () => {
+    localStorage.setItem(
+      "buckets",
+      JSON.stringify({
+        Food: [
+          { from: "0000-00", limit: 200 },
+          { from: "2026-03", limit: 300 },
+        ],
+      })
+    );
+    // Dummy entry in January so the entries tree spans Jan–May and navigation
+    // buttons are available.
+    seedEntries([
+      { date: ts(2026, JANUARY), amount: "100", type: "income", categories_path: ",salary," },
+    ]);
+
+    const { user } = await renderApp("/buckets");
+    await screen.findByText("May 2026");
+
+    // Click Food to edit from the May context.
+    await user.click(await screen.findByRole("link", { name: /edit food/i }));
+    await screen.findByText(/edit bucket: food/i);
+
+    const input = screen.getByPlaceholderText(/insert bucket amount/i);
+    await user.clear(input);
+    await user.type(input, "150");
+    await user.click(screen.getByRole("button", { name: /submit/i }));
+
+    await screen.findByText("May 2026");
+    // May: new limit 150.
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$150\.00/);
+
+    // April: unaffected, still 300.
+    await goToPrevMonth(user, "April 2026");
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$300\.00/);
+
+    // February: unaffected, still 200.
+    await goToPrevMonth(user, "March 2026");
+    await goToPrevMonth(user, "February 2026");
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$200\.00/);
+  });
+
+  it("the carry-on calculation uses the per-month limit, not a single global limit", async () => {
+    // Food: limit 200 initially, raised to 300 in March.
+    // Expenses: 250 in February (over budget by 50).
+    // March availability should be: 300 (new limit) + (-50 carry) = 250.
+    localStorage.setItem(
+      "buckets",
+      JSON.stringify({
+        Food: [
+          { from: "0000-00", limit: 200 },
+          { from: "2026-03", limit: 300 },
+        ],
+      })
+    );
+    seedEntries([
+      // Spend the entire January food allowance (200) so carry-over to February
+      // is zero — matching the test's comment that February is "over budget by 50".
+      // The January entry also anchors the entries tree to Jan–May, enabling
+      // the Prev navigation button.
+      { date: ts(2026, JANUARY), amount: "200", type: "expense", categories_path: ",food," },
+      { date: ts(2026, FEBRUARY), amount: "250", type: "expense", categories_path: ",food," },
+    ]);
+
+    const { user } = await renderApp("/buckets");
+    await screen.findByText("May 2026");
+
+    await goToPrevMonth(user, "April 2026");
+    await goToPrevMonth(user, "March 2026");
+
+    // March: allowance 300, carry-over -50 → availability 250.
+    expect(bucketCarryOver("bucket-food")).toMatch(/\$300\.00/);
+    expect(bucketAvailability("bucket-food")).toBe("$250.00");
+  });
+});

--- a/src/integrationTests/bucketsCarryOn.test.tsx
+++ b/src/integrationTests/bucketsCarryOn.test.tsx
@@ -10,6 +10,7 @@ import {
   MAY,
   DECEMBER,
 } from "./helpers/seed";
+import { goToPrevMonth } from "./helpers/navigation";
 
 // Pinned to May 2026 so the filled month tree spans December 2025 -> May 2026
 // (the range used in issue #97's worked example).
@@ -53,14 +54,6 @@ function seedIssueExample() {
     { date: ts(2026, MAY), amount: "210", type: "expense", categories_path: ",food," },
     { date: ts(2026, MAY), amount: "210", type: "expense", categories_path: ",eating out," },
   ]);
-}
-
-async function goToPrevMonth(
-  user: Awaited<ReturnType<typeof renderApp>>["user"],
-  expectedTitle: string
-) {
-  await user.click(await screen.findByRole("button", { name: /prev/i }));
-  await screen.findByText(expectedTitle);
 }
 
 function bucketCarryOver(testIdBase: string): string {

--- a/src/integrationTests/helpers/navigation.ts
+++ b/src/integrationTests/helpers/navigation.ts
@@ -1,0 +1,14 @@
+import { screen } from "@testing-library/react";
+import { renderApp } from "./renderApp";
+
+type User = Awaited<ReturnType<typeof renderApp>>["user"];
+
+export async function goToPrevMonth(user: User, expectedTitle: string): Promise<void> {
+  await user.click(await screen.findByRole("button", { name: /prev/i }));
+  await screen.findByText(expectedTitle);
+}
+
+export async function goToNextMonth(user: User, expectedTitle: string): Promise<void> {
+  await user.click(await screen.findByRole("button", { name: /next/i }));
+  await screen.findByText(expectedTitle);
+}

--- a/src/redux/expensesManager/actions.js
+++ b/src/redux/expensesManager/actions.js
@@ -1,6 +1,7 @@
 import {
   getCurrentEmptyMonth,
   getGroupedFilledEntriesByDate,
+  toYearMonth,
 } from "../../helpers/entriesHelper/entriesHelper";
 import { getCurrentTimestamp } from "../../helpers/date";
 import { getDataFromFile } from "./utils";
@@ -266,11 +267,17 @@ const GetBuckets =
 
 const EditBucket =
   ({ storage }) =>
-  ({ bucket }) => {
+  ({ bucket, selectedDate }) => {
     return async (dispatch) => {
       try {
         dispatch(setAppLoading(true));
-        const response = await storage.editBucket({ bucket });
+        const [bucketName, limit] = Object.entries(bucket)[0];
+        const fromYearMonth = toYearMonth(selectedDate.year, selectedDate.month);
+        const response = await storage.editBucket({
+          bucketName,
+          limit,
+          fromYearMonth,
+        });
         dispatch({
           type: EDIT_BUCKET,
           payload: { buckets: response },

--- a/src/services/storageSelector/LocalStorage/addBucket.test.js
+++ b/src/services/storageSelector/LocalStorage/addBucket.test.js
@@ -13,16 +13,19 @@ describe("LocalStorage.addBucket (issue #100)", () => {
 
     const result = await storage.addBucket({ bucket: { Gym: 120 } });
 
-    expect(result).toEqual({ Food: 200, Gym: 120 });
+    expect(result).toEqual({
+      Food: 200,
+      Gym: [{ from: "0000-00", limit: 120 }],
+    });
     expect(JSON.parse(localStorage.getItem("buckets"))).toEqual({
       Food: 200,
-      Gym: 120,
+      Gym: [{ from: "0000-00", limit: 120 }],
     });
   });
 
   it("trims the name and coerces the allowance to a number", async () => {
     const result = await storage.addBucket({ bucket: { "  Gym  ": "120" } });
-    expect(result).toEqual({ Gym: 120 });
+    expect(result).toEqual({ Gym: [{ from: "0000-00", limit: 120 }] });
   });
 
   it("rejects a duplicate name (case-insensitive) without persisting", async () => {

--- a/src/services/storageSelector/LocalStorage/index.js
+++ b/src/services/storageSelector/LocalStorage/index.js
@@ -38,10 +38,51 @@ const storeCategoriesInLocalStorage = storeInLocalStorageFactory({
   itemType: CATEGORIES,
 });
 
-const editBucketData = async ({ bucketData }) => {
+// Converts an old-format number value to the new per-month history array so
+// that legacy data in localStorage remains readable after the migration.
+const normalizeBucketValue = (value) => {
+  if (Array.isArray(value)) return value;
+  return [{ from: "0000-00", limit: Number(value) || 0 }];
+};
+
+// Used by the CSV restore path: overwrites all bucket limits wholesale. Each
+// incoming value is stored as a new history array rooted at "0000-00" so the
+// restored data is immediately in the current format.
+const mergeBucketsData = async ({ bucketData }) => {
   if (!bucketData) throw new Error("No bucket data was set");
   const storedBuckets = await getBucketsFromLocalStorage();
-  const newBuckets = { ...storedBuckets, ...bucketData };
+  const normalizedIncoming = Object.fromEntries(
+    Object.entries(bucketData).map(([name, value]) => [
+      name,
+      normalizeBucketValue(value),
+    ])
+  );
+  const newBuckets = { ...storedBuckets, ...normalizedIncoming };
+  await storeBucketsInLocalStorage({ data: newBuckets });
+  return newBuckets;
+};
+
+// Writes a new limit entry for `bucketName` starting from `fromYearMonth`
+// ("YYYY-MM", 1-indexed). If an entry for that exact month already exists it
+// is replaced; otherwise a new entry is appended and the history is kept
+// sorted chronologically. Old-format number values are transparently migrated
+// to the array form on the first edit.
+const editBucketForMonth = async ({ bucketName, limit, fromYearMonth }) => {
+  if (!bucketName) throw new Error("No bucket name was set");
+  const storedBuckets = (await getBucketsFromLocalStorage()) || {};
+  const history = normalizeBucketValue(storedBuckets[bucketName] ?? 0);
+
+  const existingIndex = history.findIndex((e) => e.from === fromYearMonth);
+  const updatedHistory =
+    existingIndex >= 0
+      ? history.map((e, i) =>
+          i === existingIndex ? { from: fromYearMonth, limit } : e
+        )
+      : [...history, { from: fromYearMonth, limit }];
+
+  updatedHistory.sort((a, b) => (a.from <= b.from ? -1 : 1));
+
+  const newBuckets = { ...storedBuckets, [bucketName]: updatedHistory };
   await storeBucketsInLocalStorage({ data: newBuckets });
   return newBuckets;
 };
@@ -88,7 +129,10 @@ const addBucketData = async ({ bucket }) => {
     throw new Error(`A bucket for "${trimmedName}" already exists`);
   }
 
-  const newBuckets = { ...storedBuckets, [trimmedName]: Number(value) || 0 };
+  const newBuckets = {
+    ...storedBuckets,
+    [trimmedName]: [{ from: "0000-00", limit: Number(value) || 0 }],
+  };
   await storeBucketsInLocalStorage({ data: newBuckets });
 
   const storedCategories = (await getCategoriesFromLocalStorage()) || [];
@@ -154,8 +198,8 @@ const LocalStorage = () => ({
     await storeBucketsInLocalStorage({ data: buckets });
     return getBucketsFromLocalStorage();
   },
-  editBucket: async ({ bucket }) => {
-    return editBucketData({ bucketData: bucket });
+  editBucket: async ({ bucketName, limit, fromYearMonth }) => {
+    return editBucketForMonth({ bucketName, limit, fromYearMonth });
   },
   addBucket: async ({ bucket }) => {
     return addBucketData({ bucket });
@@ -165,7 +209,7 @@ const LocalStorage = () => ({
     return addCategoryData({ category });
   },
   editBuckets: async ({ buckets }) => {
-    return editBucketData({ bucketData: buckets });
+    return mergeBucketsData({ bucketData: buckets });
   },
   getBucket: async ({ bucketName }) => {
     const buckets = await getBucketsFromLocalStorage();

--- a/src/services/storageSelector/LocalStorage/index.js
+++ b/src/services/storageSelector/LocalStorage/index.js
@@ -70,15 +70,15 @@ const mergeBucketsData = async ({ bucketData }) => {
 const editBucketForMonth = async ({ bucketName, limit, fromYearMonth }) => {
   if (!bucketName) throw new Error("No bucket name was set");
   const storedBuckets = (await getBucketsFromLocalStorage()) || {};
-  const history = normalizeBucketValue(storedBuckets[bucketName] ?? 0);
+  const historyBuckets = normalizeBucketValue(storedBuckets[bucketName] ?? 0);
 
-  const existingIndex = history.findIndex((e) => e.from === fromYearMonth);
+  const existingIndex = historyBuckets.findIndex((e) => e.from === fromYearMonth);
   const updatedHistory =
     existingIndex >= 0
-      ? history.map((e, i) =>
+      ? historyBuckets.map((e, i) =>
           i === existingIndex ? { from: fromYearMonth, limit } : e
         )
-      : [...history, { from: fromYearMonth, limit }];
+      : [...historyBuckets, { from: fromYearMonth, limit }];
 
   updatedHistory.sort((a, b) => (a.from <= b.from ? -1 : 1));
 


### PR DESCRIPTION
## Summary

Implements issue #102: bucket limit edits now apply from the selected month forward, not globally.

- **Storage format**: bucket values migrate from a flat number to a `[{ from: "YYYY-MM", limit }]` history array. Old number format is preserved and resolved transparently via `getActiveLimitForMonth()` so no data migration is needed.
- **`addBucket`**: new buckets write their initial entry as `[{ from: "0000-00", limit }]` (sentinel that applies to all historical months).
- **`editBucket`**: upserts a history entry for the month currently being viewed; months before the edit keep their original limit.
- **`EditBucket` UI**: reads the effective limit for the viewed month on load; writes back using the selected date context so the edit is anchored to that month.
- **Buckets page**: `getCarriedBucketsForMonth` now resolves each bucket's allowance per-month (existing carry-on logic is unchanged); `totalBucketAllocation` uses the resolved allowance rather than the raw bucket value.
- **Bucket list item**: gains `aria-label="Edit <Name>"` so the edit link is addressable by accessible role in tests and assistive technology.
- **`EditBucket` `onChange`**: handles empty input (clearing then re-typing now works correctly for controlled number inputs).
- **Integration tests** (`bucketLimitEdits.test.tsx`): 5 tests covering backward compatibility, per-month display, forward-only edits, and carry-on calculation with per-month limits — all passing.

## Test plan

- [x] `npm test -- --watchAll=false --testPathPattern="integrationTests"` — 39/39 pass
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no new errors in changed files
- [x] Manual trace: old-format `{ Food: 200 }` buckets still display and carry-on correctly
- [x] Manual trace: editing limit in March does not affect January/February; April and May inherit the new value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjgEYy2QkmBZX4bevJ3zuk

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjgEYy2QkmBZX4bevJ3zuk)_