### PR TITLE
Show Spent/Remaining above the bucket bar instead of redundant availability

### DIFF
--- a/src/components/common/ExpensesManager/Buckets/components/Bucket/index.tsx
+++ b/src/components/common/ExpensesManager/Buckets/components/Bucket/index.tsx
@@ -8,8 +8,8 @@ const Bucket = ({
   category,
   allowance,
   carryOver,
-  availability,
   spending,
+  remainder,
   consuptionPercentage,
 }) => {
   const colorMapClass = {
@@ -49,11 +49,11 @@ const Bucket = ({
             <Col>{category}</Col>
             <Col className="rest">
               <span data-testid={`${testId}-spending`}>
-                {formatNumberForDisplay(spending)}
+                {`Spent: ${formatNumberForDisplay(spending)}`}
               </span>
-              {" of "}
-              <span data-testid={`${testId}-availability`}>
-                {formatNumberForDisplay(availability)}
+              {" / "}
+              <span data-testid={`${testId}-remaining`}>
+                {`Remaining: ${formatNumberForDisplay(remainder)}`}
               </span>
             </Col>
           </Row>

--- a/src/components/common/ExpensesManager/Buckets/index.tsx
+++ b/src/components/common/ExpensesManager/Buckets/index.tsx
@@ -82,8 +82,8 @@ const Buckets = ({ selectedDate, entries, history, buckets }) => {
               category={bucket.label}
               allowance={bucket.allowance}
               carryOver={bucket.carryOver}
-              availability={bucket.availability}
               spending={bucket.spending}
+              remainder={bucket.remainder}
               consuptionPercentage={bucket.consuptionPercentage}
             />
           ))}

--- a/src/integrationTests/bucketLimitEdits.test.tsx
+++ b/src/integrationTests/bucketLimitEdits.test.tsx
@@ -16,8 +16,8 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-function bucketAvailability(testIdBase: string): string {
-  return screen.getByTestId(`${testIdBase}-availability`).textContent as string;
+function bucketRemaining(testIdBase: string): string {
+  return screen.getByTestId(`${testIdBase}-remaining`).textContent as string;
 }
 
 function bucketCarryOver(testIdBase: string): string {
@@ -39,7 +39,10 @@ describe("per-month bucket limit edits (issue #102)", () => {
     await goToPrevMonth(user, "February 2026");
     await goToPrevMonth(user, "January 2026");
 
-    expect(bucketAvailability("bucket-food")).toBe("$200.00");
+    expect(bucketCarryOver("bucket-food")).toBe(
+      "Allowance $200.00 + carried $0.00"
+    );
+    expect(bucketRemaining("bucket-food")).toBe("Remaining: $150.00");
   });
 
   it("new-format buckets display the effective limit for each month", async () => {
@@ -203,8 +206,10 @@ describe("per-month bucket limit edits (issue #102)", () => {
     await goToPrevMonth(user, "April 2026");
     await goToPrevMonth(user, "March 2026");
 
-    // March: allowance 300, carry-over -50 → availability 250.
-    expect(bucketCarryOver("bucket-food")).toMatch(/\$300\.00/);
-    expect(bucketAvailability("bucket-food")).toBe("$250.00");
+    // March: allowance 300, carry-over -50 → availability 250, spend 0 → remaining 250.
+    expect(bucketCarryOver("bucket-food")).toBe(
+      "Allowance $300.00 + carried $0.00 (-$50.00)"
+    );
+    expect(bucketRemaining("bucket-food")).toBe("Remaining: $250.00");
   });
 });

--- a/src/integrationTests/bucketSpentAndRemaining.test.tsx
+++ b/src/integrationTests/bucketSpentAndRemaining.test.tsx
@@ -1,0 +1,82 @@
+import { screen } from "@testing-library/react";
+import { renderApp } from "./helpers/renderApp";
+import { seedEntries, ts, APRIL, MAY } from "./helpers/seed";
+
+// Pinned to May 2026 so April is reachable as "last month" for the
+// carried-debt scenario (issue #111).
+const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem("buckets", JSON.stringify({ Food: 300 }));
+  jest.useFakeTimers();
+  jest.setSystemTime(PINNED_DATE);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+function bucketSpentText(testIdBase: string): string {
+  return screen.getByTestId(`${testIdBase}-spending`).textContent as string;
+}
+
+function bucketRemainingText(testIdBase: string): string {
+  return screen.getByTestId(`${testIdBase}-remaining`).textContent as string;
+}
+
+describe("bucket Spent/Remaining legend (issue #111)", () => {
+  it("shows Spent and Remaining above the bar when within budget", async () => {
+    // Food: allowance 300, no carry-over (first recorded month), spend 100.
+    // Remaining = 300 - 100 = 200.
+    seedEntries([
+      { date: ts(2026, MAY), amount: "100", type: "expense", categories_path: ",food," },
+    ]);
+
+    await renderApp("/buckets");
+    await screen.findByText("May 2026");
+
+    expect(bucketSpentText("bucket-food")).toBe("Spent: $100.00");
+    expect(bucketRemainingText("bucket-food")).toBe("Remaining: $200.00");
+  });
+
+  it("shows a negative Remaining when the current month is overspent", async () => {
+    // Food: allowance 300, no carry-over, spend 420.
+    // Remaining = 300 - 420 = -120.
+    seedEntries([
+      { date: ts(2026, MAY), amount: "420", type: "expense", categories_path: ",food," },
+    ]);
+
+    await renderApp("/buckets");
+    await screen.findByText("May 2026");
+
+    expect(bucketSpentText("bucket-food")).toBe("Spent: $420.00");
+    expect(bucketRemainingText("bucket-food")).toBe("Remaining: -$120.00");
+  });
+
+  it("shows a negative Remaining carried in from a prior month's overspend, even with no spending this month", async () => {
+    // April: allowance 300, spend 700 -> remainder -400.
+    // May (current, no entries): availability = 300 + (-400) = -100, spend 0.
+    // Remaining = -100 - 0 = -100.
+    seedEntries([
+      { date: ts(2026, APRIL), amount: "700", type: "expense", categories_path: ",food," },
+    ]);
+
+    await renderApp("/buckets");
+    await screen.findByText("May 2026");
+
+    expect(bucketSpentText("bucket-food")).toBe("Spent: $0.00");
+    expect(bucketRemainingText("bucket-food")).toBe("Remaining: -$100.00");
+  });
+
+  it("no longer shows the redundant availability figure above the bar", async () => {
+    seedEntries([
+      { date: ts(2026, MAY), amount: "100", type: "expense", categories_path: ",food," },
+    ]);
+
+    await renderApp("/buckets");
+    await screen.findByText("May 2026");
+
+    expect(screen.queryByTestId("bucket-food-availability")).toBeNull();
+  });
+});

--- a/src/integrationTests/bucketsCarryOn.test.tsx
+++ b/src/integrationTests/bucketsCarryOn.test.tsx
@@ -59,8 +59,8 @@ function seedIssueExample() {
 function bucketCarryOver(testIdBase: string): string {
   return screen.getByTestId(`${testIdBase}-carry-over`).textContent as string;
 }
-function bucketAvailability(testIdBase: string): string {
-  return screen.getByTestId(`${testIdBase}-availability`).textContent as string;
+function bucketRemaining(testIdBase: string): string {
+  return screen.getByTestId(`${testIdBase}-remaining`).textContent as string;
 }
 function bucketSpending(testIdBase: string): string {
   return screen.getByTestId(`${testIdBase}-spending`).textContent as string;
@@ -80,21 +80,18 @@ describe("buckets carry-on (issue #97)", () => {
     await goToPrevMonth(user, "December 2025");
 
     // Food: availability (200 + 0) = 200, spend 200 -> remainder 0
-    expect(bucketAvailability("bucket-food")).toBe("$200.00");
-    expect(bucketSpending("bucket-food")).toBe("$200.00");
+    expect(bucketSpending("bucket-food")).toBe("Spent: $200.00");
+    expect(bucketRemaining("bucket-food")).toBe("Remaining: $0.00");
     expect(bucketCarryOver("bucket-food")).toBe(
       "Allowance $200.00 + carried $0.00"
     );
 
     // Eating out: availability (300 + 0) = 300, spend 300 -> remainder 0
-    expect(bucketAvailability("bucket-eating-out")).toBe("$300.00");
-    expect(bucketSpending("bucket-eating-out")).toBe("$300.00");
+    expect(bucketSpending("bucket-eating-out")).toBe("Spent: $300.00");
+    expect(bucketRemaining("bucket-eating-out")).toBe("Remaining: $0.00");
 
     // Percentage is spending vs. carried availability (200 / 200 = 100%).
     expect(screen.getByTestId("bucket-food-percentage").textContent).toBe("100%");
-
-    // The standalone remaining line has been removed.
-    expect(screen.queryByTestId("bucket-food-remaining")).toBeNull();
   });
 
   it("accumulates a positive remainder into the next month's availability", async () => {
@@ -111,14 +108,14 @@ describe("buckets carry-on (issue #97)", () => {
     expect(bucketCarryOver("bucket-food")).toBe(
       "Allowance $200.00 + carried $50.00"
     );
-    expect(bucketAvailability("bucket-food")).toBe("$250.00");
-    expect(bucketSpending("bucket-food")).toBe("$20.00");
+    expect(bucketSpending("bucket-food")).toBe("Spent: $20.00");
+    expect(bucketRemaining("bucket-food")).toBe("Remaining: $230.00");
 
     // Eating out: carry 150, availability (300 + 150) = 450, spend 20 (remainder 430)
     expect(bucketCarryOver("bucket-eating-out")).toBe(
       "Allowance $300.00 + carried $150.00"
     );
-    expect(bucketAvailability("bucket-eating-out")).toBe("$450.00");
+    expect(bucketRemaining("bucket-eating-out")).toBe("Remaining: $430.00");
   });
 
   it("carries debt forward into the next month as $0.00 (-deficit)", async () => {
@@ -136,13 +133,13 @@ describe("buckets carry-on (issue #97)", () => {
     expect(bucketCarryOver("bucket-food")).toBe(
       "Allowance $200.00 + carried $0.00 (-$10.00)"
     );
-    expect(bucketAvailability("bucket-food")).toBe("$190.00");
-    expect(bucketSpending("bucket-food")).toBe("$0.00");
+    expect(bucketSpending("bucket-food")).toBe("Spent: $0.00");
+    expect(bucketRemaining("bucket-food")).toBe("Remaining: $190.00");
 
-    // The May overspend itself reads as $210 of $200 (over budget, 105%).
+    // The May overspend itself reads as Spent $210.00, Remaining -$10.00 (over budget, 105%).
     await goToPrevMonth(user, "May 2026");
-    expect(bucketSpending("bucket-food")).toBe("$210.00");
-    expect(bucketAvailability("bucket-food")).toBe("$200.00");
+    expect(bucketSpending("bucket-food")).toBe("Spent: $210.00");
+    expect(bucketRemaining("bucket-food")).toBe("Remaining: -$10.00");
     expect(screen.getByTestId("bucket-food-percentage").textContent).toBe(
       "105%"
     );
@@ -165,8 +162,8 @@ describe("buckets carry-on (issue #97)", () => {
     expect(bucketCarryOver("bucket-food")).toBe(
       "Allowance $200.00 + carried $0.00 (-$50.00)"
     );
-    expect(bucketAvailability("bucket-food")).toBe("$150.00");
-    expect(bucketSpending("bucket-food")).toBe("$100.00");
+    expect(bucketSpending("bucket-food")).toBe("Spent: $100.00");
+    expect(bucketRemaining("bucket-food")).toBe("Remaining: $50.00");
   });
 
   it("shows negative availability as $0.00 (-deficit) when debt exceeds the allowance", async () => {
@@ -185,9 +182,9 @@ describe("buckets carry-on (issue #97)", () => {
     expect(bucketCarryOver("bucket-food")).toBe(
       "Allowance $200.00 + carried $0.00 (-$300.00)"
     );
-    // Carried uses the "$0.00 (-deficit)" form; availability shows the raw
-    // negative ("$0.00 of -$100.00").
-    expect(bucketAvailability("bucket-food")).toBe("-$100.00");
-    expect(bucketSpending("bucket-food")).toBe("$0.00");
+    // Carried uses the "$0.00 (-deficit)" form; Remaining shows the raw
+    // negative amount.
+    expect(bucketSpending("bucket-food")).toBe("Spent: $0.00");
+    expect(bucketRemaining("bucket-food")).toBe("Remaining: -$100.00");
   });
 });

--- a/src/integrationTests/categoryBucketCreation.test.tsx
+++ b/src/integrationTests/categoryBucketCreation.test.tsx
@@ -52,8 +52,8 @@ describe("category + bucket creation (issue #100)", () => {
 
     // Redirected back to the buckets list with the freshly bucketed category.
     expect(await screen.findByText("Gym")).toBeInTheDocument();
-    expect(screen.getByTestId("bucket-gym-availability").textContent).toBe(
-      "$120.00"
+    expect(screen.getByTestId("bucket-gym-remaining").textContent).toBe(
+      "Remaining: $120.00"
     );
   });
 

--- a/src/integrationTests/singleFileBackup.test.tsx
+++ b/src/integrationTests/singleFileBackup.test.tsx
@@ -463,11 +463,11 @@ describe("round trip — download produces a single JSON file that restores the 
     expect(screen.getByTestId("bucket-food-carry-over").textContent).toBe(
       "Allowance $200.00 + carried $0.00"
     );
-    expect(screen.getByTestId("bucket-food-availability").textContent).toBe(
-      "$200.00"
-    );
     expect(screen.getByTestId("bucket-food-spending").textContent).toBe(
-      "$50.00"
+      "Spent: $50.00"
+    );
+    expect(screen.getByTestId("bucket-food-remaining").textContent).toBe(
+      "Remaining: $150.00"
     );
 
     // The standalone category came back.


### PR DESCRIPTION
## Summary

Closes #111.

The bucket legend above the progress bar showed `$X of $Y` (spent of availability), which duplicated the allowance/carry-over figures already shown below the bar and never told the user how much they had left to spend. This replaces it with `Spent: $X / Remaining: $Y`, where `Remaining` is the bucket's already-computed `remainder` (availability − spending).

- `Bucket/index.tsx`: legend row now renders `Spent: {spending}` / `Remaining: {remainder}` instead of `{spending} of {availability}`; dropped the now-unused `availability` prop.
- `Buckets/index.tsx`: passes `remainder` down to `Bucket` instead of `availability`.
- Remaining can be negative (current-month overspend, or debt carried in from a prior month) — it renders as `-$X.XX`, same negative formatting already used elsewhere (e.g. carried debt).
- Below-the-bar allowance/carry-over line and percentage are unchanged.

## Test plan

- [x] Added `src/integrationTests/bucketSpentAndRemaining.test.tsx` (written test-first, confirmed red against the old implementation): within-budget, current-month overspend, debt carried in from a prior month, and removal of the redundant availability testid.
- [x] Updated existing integration tests that asserted on the removed `-availability` testid / old `$X of $Y` text (`bucketsCarryOn`, `bucketLimitEdits`, `categoryBucketCreation`, `singleFileBackup`) to the new format.
- [x] `npm test -- --testPathPattern="integrationTests"` — all 64 tests pass.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — no new issues (pre-existing warnings/errors unchanged, verified via diff against master).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qmg5LABtM7DiZZkQyJG7HN)_