### PR TITLE
Add totals to Fixed Entries incomes/expenses sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.2] - 2026-07-09
+
+### Added
+- Fixed Entries: section totals for the Incomes and Expenses lists, showing
+  the sum of the recurring entries applying to the viewed month (#113)
+
 ## [1.0.0] - 2026-07-05
 
 First stable release. This version consolidates the buckets, categories,
@@ -47,4 +53,5 @@ fixed-entries, and backup/restore work into a single supported release.
   Entries pages
 - Stale personal references and ESLint warnings removed; license file fixed
 
+[1.0.2]: https://github.com/rivasvict/react-expenses-manager/releases/tag/v1.0.2
 [1.0.0]: https://github.com/rivasvict/react-expenses-manager/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,4 @@ Node version is pinned in `.nvmrc`.
 * Make sure to run `npm run typecheck` on every edition to catch TypeScript errors early.
 * Use arrow functions by default. Only use regular `function` declarations when syntax requires it (e.g. generator functions, methods that need their own `this` binding in class components).
 * In integration tests, verify behaviour through what the user sees on screen (`screen.findByText`, `screen.getByRole`, etc.) rather than inspecting Redux store state or `localStorage` directly. Raw data-structure checks are an implementation detail; UI assertions test what actually matters.
+* Every pull request must bump the app version: update `"version"` in `package.json` (and `package-lock.json`) and add a corresponding entry to `CHANGELOG.md`, following the existing `Keep a Changelog` format used there.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "0.1.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "0.1.0",
+      "version": "1.0.2",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/src/components/common/ExpensesManager/FixedEntries/index.js
+++ b/src/components/common/ExpensesManager/FixedEntries/index.js
@@ -13,6 +13,9 @@ import "./styles.scss";
 const getFixedOfType = (monthEntries, plural) =>
   (monthEntries?.[plural] || []).filter((entry) => entry.isFixed);
 
+const sumAmounts = (entries) =>
+  entries.reduce((total, entry) => total + Number(entry.amount), 0);
+
 /**
  * Lists the recurring (fixed) incomes and expenses that apply to the viewed
  * month (issue #103), reusing the same row component as the regular monthly
@@ -50,6 +53,7 @@ const FixedEntries = ({ entries, selectedDate, history }) => {
               entries={fixedIncomes}
               name="incomes"
               entryType="income"
+              total={sumAmounts(fixedIncomes)}
             />
           )}
           {fixedExpenses.length > 0 && (
@@ -57,6 +61,7 @@ const FixedEntries = ({ entries, selectedDate, history }) => {
               entries={fixedExpenses}
               name="expenses"
               entryType="expense"
+              total={sumAmounts(fixedExpenses)}
             />
           )}
         </>

--- a/src/components/common/ExpensesManager/Summaries/EntriesSummary.js
+++ b/src/components/common/ExpensesManager/Summaries/EntriesSummary.js
@@ -33,14 +33,19 @@ function GetEntriesList({ entries, entryType }) {
   });
 }
 
-function EntriesSummary({ entries, name, entryType }) {
+function EntriesSummary({ entries, name, entryType, total }) {
   const entriesList = GetEntriesList({ entries, entryType });
   return (
     <Container className="entries-summary">
       <Row>
-        <Col xs={12} className="item-type">
+        <Col xs={total === undefined ? 12 : 8} className="item-type">
           {capitalize(name)}
         </Col>
+        {total !== undefined && (
+          <Col xs={4} className="item-total">
+            {formatNumberForDisplay(total)}
+          </Col>
+        )}
       </Row>
       {entriesList.length ? entriesList : null}
     </Container>

--- a/src/components/common/ExpensesManager/Summaries/EntriesSummary.scss
+++ b/src/components/common/ExpensesManager/Summaries/EntriesSummary.scss
@@ -2,6 +2,11 @@
 
 .entries-summary {
 
+  .item-total {
+    @include adjust-text-in-vertical-axis();
+    justify-content: flex-end;
+  }
+
   .entries-item {
     margin-top: $vertical-standard-margin;
     margin-bottom: $vertical-standard-margin;

--- a/src/integrationTests/fixedEntries.test.tsx
+++ b/src/integrationTests/fixedEntries.test.tsx
@@ -48,6 +48,28 @@ const addRecurringExpense = async (
   await screen.findByRole("link", { name: /add expenses/i });
 };
 
+// Adds a recurring income from the dashboard using the normal Add Income form
+// with the "Recurring" toggle switched on.
+const addRecurringIncome = async (
+  user: UserEvent,
+  { amount, description }: { amount: string; description: string }
+) => {
+  await user.click(await screen.findByRole("link", { name: /add income/i }));
+  await user.type(
+    await screen.findByPlaceholderText(/insert income amount/i),
+    amount
+  );
+  await user.type(screen.getByPlaceholderText(/description/i), description);
+  await user.selectOptions(
+    screen.getByRole("combobox"),
+    screen.getByRole("option", { name: "Salary" })
+  );
+  await user.click(screen.getByLabelText(/recurring/i));
+  await user.click(screen.getByRole("button", { name: /submit/i }));
+  // Back on the dashboard after submitting.
+  await screen.findByRole("link", { name: /add income/i });
+};
+
 // Adds a one-off (non-recurring) expense via the same form but WITHOUT the toggle.
 const addRegularExpense = async (
   user: UserEvent,
@@ -111,7 +133,9 @@ describe("toggle routing — recurring vs regular entries", () => {
     await user.click(screen.getByRole("link", { name: /fixed entries/i }));
     await screen.findByText("March 2026");
     expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
-    expect(screen.getByText("$150.00")).toBeInTheDocument();
+    // $150.00 appears twice: the entry's own amount and the section total
+    // (only one fixed expense this month, so the total equals it).
+    expect(screen.getAllByText("$150.00")).toHaveLength(2);
   });
 
   it("a recurring expense materialises into the dashboard total and is visible on the Fixed Entries page", async () => {
@@ -153,7 +177,8 @@ describe("fixed entries without any prior regular entries", () => {
     await user.click(screen.getByRole("link", { name: /fixed entries/i }));
     await screen.findByText("May 2026");
     expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
-    expect(screen.getByText("$100.00")).toBeInTheDocument();
+    // $100.00 appears twice: the entry's own amount and the section total.
+    expect(screen.getAllByText("$100.00")).toHaveLength(2);
   });
 });
 
@@ -214,7 +239,8 @@ describe("toggling recurring ON in the edit form converts a one-off entry to a f
     // the promotion happens) with the correct amount.
     await screen.findByText("May 2026");
     expect(await screen.findByText(/Food - Coffee/)).toBeInTheDocument();
-    expect(screen.getByText("$90.00")).toBeInTheDocument();
+    // $90.00 appears twice: the entry's own amount and the section total.
+    expect(screen.getAllByText("$90.00")).toHaveLength(2);
 
     // Fixed entries are also materialised into the regular expenses view.
     await user.click(screen.getByRole("link", { name: /home/i }));
@@ -326,5 +352,119 @@ describe("fixed (recurring) entries reuse the regular entry flow (issue #103)", 
     await goToPrevMonth(user, "April 2026");
     await goToPrevMonth(user, "March 2026");
     expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
+  });
+});
+
+describe("Fixed Entries totals (issue #113)", () => {
+  it("shows the sum of each section when both incomes and expenses exist", async () => {
+    const { user } = await renderApp("/");
+    await goToPrevMonth(user, "April 2026");
+    await goToPrevMonth(user, "March 2026");
+
+    await addRecurringIncome(user, { amount: "1000", description: "Salary" });
+    await addRecurringIncome(user, { amount: "500", description: "Bonus" });
+    await addRecurringExpense(user, { amount: "200", description: "Groceries" });
+    await addRecurringExpense(user, { amount: "50", description: "Snacks" });
+
+    await user.click(screen.getByRole("link", { name: /fixed entries/i }));
+    await screen.findByText("March 2026");
+
+    // Line items.
+    expect(await screen.findByText("$1,000.00")).toBeInTheDocument();
+    expect(screen.getByText("$500.00")).toBeInTheDocument();
+    expect(screen.getByText("$200.00")).toBeInTheDocument();
+    expect(screen.getByText("$50.00")).toBeInTheDocument();
+
+    // Section totals: incomes 1000 + 500 = 1500, expenses 200 + 50 = 250.
+    expect(screen.getByText("$1,500.00")).toBeInTheDocument();
+    expect(screen.getByText("$250.00")).toBeInTheDocument();
+  });
+
+  it("shows only the expenses total when there are no fixed incomes", async () => {
+    const { user } = await renderApp("/");
+    await goToPrevMonth(user, "April 2026");
+    await goToPrevMonth(user, "March 2026");
+
+    await addRecurringExpense(user, { amount: "200", description: "Rent" });
+    await addRecurringExpense(user, { amount: "50", description: "Netflix" });
+
+    await user.click(screen.getByRole("link", { name: /fixed entries/i }));
+    await screen.findByText("March 2026");
+
+    // No fixed incomes, so the Incomes section is not rendered at all.
+    expect(screen.queryByText("Incomes")).not.toBeInTheDocument();
+
+    // Expenses total: 200 + 50 = 250, distinct from either line item.
+    expect(await screen.findByText("$250.00")).toBeInTheDocument();
+    expect(screen.getByText("$200.00")).toBeInTheDocument();
+    expect(screen.getByText("$50.00")).toBeInTheDocument();
+  });
+
+  it("shows only the incomes total when there are no fixed expenses", async () => {
+    const { user } = await renderApp("/");
+    await goToPrevMonth(user, "April 2026");
+    await goToPrevMonth(user, "March 2026");
+
+    await addRecurringIncome(user, { amount: "1000", description: "Salary" });
+    await addRecurringIncome(user, { amount: "300", description: "Bonus" });
+
+    await user.click(screen.getByRole("link", { name: /fixed entries/i }));
+    await screen.findByText("March 2026");
+
+    // No fixed expenses, so the Expenses section is not rendered at all.
+    expect(screen.queryByText("Expenses")).not.toBeInTheDocument();
+
+    // Incomes total: 1000 + 300 = 1300, distinct from either line item.
+    expect(await screen.findByText("$1,300.00")).toBeInTheDocument();
+    expect(screen.getByText("$1,000.00")).toBeInTheDocument();
+    expect(screen.getByText("$300.00")).toBeInTheDocument();
+  });
+
+  it("shows no totals when there are no fixed entries at all", async () => {
+    const { user } = await renderApp("/");
+    await goToPrevMonth(user, "April 2026");
+    await goToPrevMonth(user, "March 2026");
+
+    await user.click(screen.getByRole("link", { name: /fixed entries/i }));
+    await screen.findByText("March 2026");
+
+    expect(
+      await screen.findByText(/no recurring entries apply to this month yet/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Incomes")).not.toBeInTheDocument();
+    expect(screen.queryByText("Expenses")).not.toBeInTheDocument();
+  });
+
+  it("recomputes totals after navigating to a month with a different amount", async () => {
+    const { user } = await renderApp("/");
+    await goToPrevMonth(user, "April 2026");
+    await goToPrevMonth(user, "March 2026");
+    await addRecurringExpense(user, { amount: "200", description: "Groceries" });
+    await addRecurringExpense(user, { amount: "50", description: "Snacks" });
+
+    await user.click(screen.getByRole("link", { name: /fixed entries/i }));
+    await screen.findByText("March 2026");
+    // March total: 200 + 50 = 250.
+    expect(await screen.findByText("$250.00")).toBeInTheDocument();
+
+    // Edit "Snacks" while viewing April → 75 from April forward.
+    await goToNextMonth(user, "April 2026");
+    await user.click(await screen.findByText(/Food - Snacks/));
+    const amountInput = await screen.findByPlaceholderText(
+      /insert expense amount/i
+    );
+    await user.clear(amountInput);
+    await user.type(amountInput, "75");
+    await user.click(screen.getByRole("button", { name: /submit/i }));
+
+    // April total: 200 + 75 = 275.
+    await screen.findByText("April 2026");
+    expect(await screen.findByText("$275.00")).toBeInTheDocument();
+    expect(screen.queryByText("$250.00")).not.toBeInTheDocument();
+
+    // March keeps its original total (forward-only edit).
+    await goToPrevMonth(user, "March 2026");
+    expect(await screen.findByText("$250.00")).toBeInTheDocument();
+    expect(screen.queryByText("$275.00")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Show a total next to each section header on the Fixed Entries page: the sum of the fixed incomes and the sum of the fixed expenses applying to the viewed month.
- `EntriesSummary` gains an optional `total` prop (used only by Fixed Entries for now — other callers are unaffected).

Closes #113

## Changes
- `FixedEntries/index.js`: computes the sum of each section's entries and passes it to `EntriesSummary`.
- `Summaries/EntriesSummary.js` / `.scss`: renders an optional total, right-aligned in the same column as the entry amounts.
- `CHANGELOG.md` / `package.json` / `package-lock.json`: bump to **1.0.2**.
- `CLAUDE.md`: added a note that every PR must bump the app version going forward.

## Test plan
- [x] Added integration tests in `src/integrationTests/fixedEntries.test.tsx`: both sections present, expenses-only, incomes-only, no fixed entries, and totals recomputing after month navigation.
- [x] Updated 3 pre-existing tests whose single-entry assertions became ambiguous now that the total duplicates that entry's amount.
- [x] `npm test -- --testPathPattern="integrationTests"` — 69/69 passing.
- [x] `npm run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EQkiCLi6k6gH92GU61Hx4P)_