### PR TITLE
Add CI pipelines for unit and integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,24 @@
+name: Integration Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - run: npm ci
+
+      - run: npm test -- --watchAll=false --testPathPattern="integrationTests"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,24 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - run: npm ci
+
+      - run: npm test -- --watchAll=false --testPathIgnorePatterns="integrationTests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.4] - 2026-07-10
+
+### Added
+- CI: `unit-tests` and `integration-tests` GitHub Actions workflows, running
+  on push to `master` and on pull requests targeting `master`. Both pin
+  Node via `.nvmrc`, install with `npm ci`, and split the suite using the
+  existing `testPathPattern="integrationTests"` convention
+
 ## [1.0.3] - 2026-07-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",


### PR DESCRIPTION
## Summary
- Add `.github/workflows/unit-tests.yml` and `.github/workflows/integration-tests.yml`, splitting CI into two pipelines using the existing `testPathPattern="integrationTests"` convention (one runs everything under `src/integrationTests`, the other runs everything else).
- Both workflows use the Node version pinned in `.nvmrc` (16.13.1) with npm caching, and install via `npm ci`.
- Triggers: push to `master`, and pull requests targeting `master`.

## Test plan
- [x] Verified locally with Node 16.13.1 (matching `.nvmrc`) that `npm test -- --watchAll=false --testPathPattern="integrationTests"` passes (8/8 suites, 52/52 tests).
- [x] Verified locally that `npm test -- --watchAll=false --testPathIgnorePatterns="integrationTests"` runs the unit suite correctly (note: 7 pre-existing suite failures unrelated to this change — not introduced by this PR).
- [ ] Confirm both workflows show up and pass in GitHub Actions once merged.
- [ ] Add branch protection on `master` requiring the `unit-tests` and `integration-tests` checks to actually gate merges (not done in this PR — requires repo admin access).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LFrQd8mBpyHMFv3S9JKdWG)_