### PR TITLE
Party management: block & cancel (PR 3/6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.0] - 2026-07-12
+
+### Added
+- Party management (multi-user sync, PR 3): the organizer can block a
+  member (confirm dialog; the member keeps their record and their
+  already-contributed entries, but immediately loses sync access) and
+  cancel the party (confirm dialog; nobody's local data is touched)
+- Blocked members and members of a canceled party see dedicated `/party`
+  views explaining what happened, and are free to create or join another
+  party
+- Server: block/cancel endpoints plus a shared party-access enforcement
+  layer — blocked members get 403 BLOCKED and canceled parties 410
+  PARTY_CANCELED on the backup endpoints, so the upcoming sync
+  implementation inherits the enforcement unchanged
+- Organizer-only visibility for Block/Cancel controls; members see a
+  read-only list
+
 ## [1.3.0] - 2026-07-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/server/core/handlers.js
+++ b/server/core/handlers.js
@@ -30,7 +30,11 @@ const ERROR_CODES = {
   INVITATION_NOT_FOUND: "INVITATION_NOT_FOUND",
   INVITATION_WRONG_PASSWORD: "INVITATION_WRONG_PASSWORD",
   INVITATION_USED: "INVITATION_USED",
+  BLOCKED: "BLOCKED",
+  NO_BACKUP: "NO_BACKUP",
   CONFLICT: "CONFLICT",
+  // Temporary scaffolding only (PUT backup body arrives with the sync PR).
+  NOT_IMPLEMENTED: "NOT_IMPLEMENTED",
 };
 
 const error = (status, code, message) => ({
@@ -206,11 +210,52 @@ const createHandlers = ({ storage, tokenSecret, encryptionKey, now = Date.now })
     return { status: 200, body: { user: publicUser(user), party } };
   };
 
+  // DESIGN §3.6: being blocked, or belonging to a canceled party, leaves
+  // the user free to create/join elsewhere. Their member record stays
+  // behind in the old party (AC-2.9 — attribution history is never
+  // retroactively removed); only user.partyId moves on.
+  const hasActivePartyMembership = async (user) => {
+    if (!user.partyId) return false;
+    const record = await storage.readJsonVersioned(partyKey(user.partyId));
+    if (!record) return false;
+    const party = record.value;
+    if (party.canceled) return false;
+    const member = party.members.find((candidate) => candidate.id === user.id);
+    return !(member && member.blocked);
+  };
+
+  // Shared enforcement layer for everything that touches the party's data
+  // (EC-9, AC-2.10/2.11): resolves the caller's party access or fails with
+  // UNAUTHORIZED / NO_PARTY / BLOCKED / PARTY_CANCELED. The backup
+  // endpoints below run through it, so PR 4's real implementations inherit
+  // the enforcement unchanged — a stale client can never download or
+  // upload.
+  const requirePartyAccess = async (request) => {
+    const user = await authenticate(request);
+    if (!user) return unauthorized();
+    if (!user.partyId)
+      return error(404, ERROR_CODES.NO_PARTY, "You don't belong to a party.");
+    const record = await storage.readJsonVersioned(partyKey(user.partyId));
+    if (!record)
+      return error(404, ERROR_CODES.NO_PARTY, "You don't belong to a party.");
+    const party = record.value;
+    const member = party.members.find((candidate) => candidate.id === user.id);
+    if (member && member.blocked)
+      return error(
+        403,
+        ERROR_CODES.BLOCKED,
+        "You've been removed from this party by its organizer."
+      );
+    if (party.canceled)
+      return error(410, ERROR_CODES.PARTY_CANCELED, "This party was canceled.");
+    return { user, party, version: record.version };
+  };
+
   // RFC §3.4 — create a party; the creator becomes its organizer (AC-2.1).
   const createParty = async (request) => {
     const user = await authenticate(request);
     if (!user) return unauthorized();
-    if (user.partyId)
+    if (await hasActivePartyMembership(user))
       return error(
         409,
         ERROR_CODES.ALREADY_IN_PARTY,
@@ -298,8 +343,10 @@ const createHandlers = ({ storage, tokenSecret, encryptionKey, now = Date.now })
         ERROR_CODES.VALIDATION_ERROR,
         "An invitation code and password are required."
       );
-    // EC-6 first: an existing membership never consumes the invitation.
-    if (user.partyId)
+    // EC-6 first: an existing (active) membership never consumes the
+    // invitation. Blocked members and members of canceled parties are
+    // free to join elsewhere (DESIGN §3.6).
+    if (await hasActivePartyMembership(user))
       return error(
         409,
         ERROR_CODES.ALREADY_IN_PARTY,
@@ -359,10 +406,22 @@ const createHandlers = ({ storage, tokenSecret, encryptionKey, now = Date.now })
     const outcome = await mutateParty(pointer.partyId, (party) => {
       const revalidated = validate(party);
       if (!revalidated.invitation) return revalidated;
+      // Re-invited past member (e.g. previously blocked): refresh the
+      // existing record instead of appending a duplicate row.
+      const isReturning = party.members.some(
+        (member) => member.id === user.id
+      );
+      const members = isReturning
+        ? party.members.map((member) =>
+            member.id === user.id
+              ? { ...publicUser(user), blocked: false }
+              : member
+          )
+        : [...party.members, { ...publicUser(user), blocked: false }];
       return {
         party: {
           ...party,
-          members: [...party.members, { ...publicUser(user), blocked: false }],
+          members,
           invitations: {
             ...party.invitations,
             [lookupHash]: encryptRecord(
@@ -378,7 +437,106 @@ const createHandlers = ({ storage, tokenSecret, encryptionKey, now = Date.now })
     return { status: 200, body: { party: publicParty(outcome.party, user.id) } };
   };
 
-  return { signup, login, me, createParty, createInvitation, joinParty };
+  // RFC §3.7 — organizer blocks a member (AC-2.9). The member keeps their
+  // membership record — already-contributed entries are never
+  // retroactively removed — but the flag immediately revokes party-data
+  // access (EC-9) via requirePartyAccess. Nothing outside the party
+  // record is touched.
+  const blockMember = async (request) => {
+    const user = await authenticate(request);
+    if (!user) return unauthorized();
+    if (!user.partyId)
+      return error(404, ERROR_CODES.NO_PARTY, "You don't belong to a party.");
+    const targetId = (request.params || {}).userId;
+    const outcome = await mutateParty(user.partyId, (party) => {
+      if (party.organizerId !== user.id)
+        return error(
+          403,
+          ERROR_CODES.NOT_ORGANIZER,
+          "Only the organizer can block members."
+        );
+      if (targetId === party.organizerId)
+        return error(
+          400,
+          ERROR_CODES.VALIDATION_ERROR,
+          "The organizer cannot be blocked."
+        );
+      if (!party.members.some((member) => member.id === targetId))
+        return error(
+          404,
+          ERROR_CODES.NOT_FOUND,
+          "That member isn't in your party."
+        );
+      return {
+        party: {
+          ...party,
+          members: party.members.map((member) =>
+            member.id === targetId ? { ...member, blocked: true } : member
+          ),
+        },
+      };
+    });
+    if (!outcome.party) return outcome;
+    return { status: 200, body: { party: publicParty(outcome.party, user.id) } };
+  };
+
+  // RFC §3.8 — organizer cancels the party (AC-2.10). Members keep their
+  // records and their local data; the flag makes every future party-data
+  // call fail with PARTY_CANCELED via requirePartyAccess.
+  const cancelParty = async (request) => {
+    const user = await authenticate(request);
+    if (!user) return unauthorized();
+    if (!user.partyId)
+      return error(404, ERROR_CODES.NO_PARTY, "You don't belong to a party.");
+    const outcome = await mutateParty(user.partyId, (party) => {
+      if (party.organizerId !== user.id)
+        return error(
+          403,
+          ERROR_CODES.NOT_ORGANIZER,
+          "Only the organizer can cancel the party."
+        );
+      return { party: { ...party, canceled: true } };
+    });
+    if (!outcome.party) return outcome;
+    return { status: 200, body: { party: publicParty(outcome.party, user.id) } };
+  };
+
+  // RFC §3.9–3.10 land with the sync PR; the routes exist now so the
+  // blocked/canceled enforcement (requirePartyAccess) is already in force
+  // for them and PR 4 inherits it unchanged.
+  const getBackup = async (request) => {
+    const access = await requirePartyAccess(request);
+    if (!access.user) return access;
+    // No backups can exist yet — EC-1's contract answer is the truth.
+    return error(
+      404,
+      ERROR_CODES.NO_BACKUP,
+      "No backup has been uploaded yet."
+    );
+  };
+
+  const putBackup = async (request) => {
+    const access = await requirePartyAccess(request);
+    if (!access.user) return access;
+    return error(
+      501,
+      ERROR_CODES.NOT_IMPLEMENTED,
+      "Backup upload arrives with sync."
+    );
+  };
+
+  return {
+    signup,
+    login,
+    me,
+    createParty,
+    createInvitation,
+    joinParty,
+    blockMember,
+    cancelParty,
+    getBackup,
+    putBackup,
+  };
 };
 
 module.exports = { createHandlers, ERROR_CODES };

--- a/server/core/router.js
+++ b/server/core/router.js
@@ -5,6 +5,25 @@
 const { createHandlers, ERROR_CODES } = require("./handlers");
 const { deriveEncryptionKey } = require("./invitations");
 
+// Matches "/api/party/members/abc/block" against
+// "/api/party/members/:userId/block" → { userId: "abc" }, or null.
+const matchPath = (pattern, path) => {
+  const patternParts = pattern.split("/");
+  const pathParts = path.split("/");
+  if (patternParts.length !== pathParts.length) return null;
+  const params = {};
+  for (let index = 0; index < patternParts.length; index += 1) {
+    if (patternParts[index].startsWith(":")) {
+      params[patternParts[index].slice(1)] = decodeURIComponent(
+        pathParts[index]
+      );
+    } else if (patternParts[index] !== pathParts[index]) {
+      return null;
+    }
+  }
+  return params;
+};
+
 const createApp = ({ storage, tokenSecret, encryptionSecret, now }) => {
   const handlers = createHandlers({
     storage,
@@ -24,20 +43,27 @@ const createApp = ({ storage, tokenSecret, encryptionSecret, now }) => {
       handler: handlers.createInvitation,
     },
     { method: "POST", path: "/api/party/join", handler: handlers.joinParty },
+    {
+      method: "POST",
+      path: "/api/party/members/:userId/block",
+      handler: handlers.blockMember,
+    },
+    { method: "POST", path: "/api/party/cancel", handler: handlers.cancelParty },
+    { method: "GET", path: "/api/party/backup", handler: handlers.getBackup },
+    { method: "PUT", path: "/api/party/backup", handler: handlers.putBackup },
   ];
 
   // request: { method, path, headers, body } → { status, body }
   const handle = async (request) => {
-    const route = routes.find(
-      (candidate) =>
-        candidate.method === request.method && candidate.path === request.path
-    );
-    if (!route)
-      return {
-        status: 404,
-        body: { error: { code: ERROR_CODES.NOT_FOUND, message: "Not found." } },
-      };
-    return route.handler(request);
+    for (const route of routes) {
+      if (route.method !== request.method) continue;
+      const params = matchPath(route.path, request.path);
+      if (params !== null) return route.handler({ ...request, params });
+    }
+    return {
+      status: 404,
+      body: { error: { code: ERROR_CODES.NOT_FOUND, message: "Not found." } },
+    };
   };
 
   return { handle };

--- a/server/test/partyManagement.test.js
+++ b/server/test/partyManagement.test.js
@@ -1,0 +1,254 @@
+// Contract tests for RFC §3.7–3.8 (block member, cancel party) and the
+// blocked/canceled enforcement layer the backup endpoints inherit
+// (EC-9, AC-2.9–2.12).
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { createApp } = require("../core/router");
+const { createMemoryStorage } = require("../core/storage");
+
+const TOKEN_SECRET = "test-secret";
+
+const makeApp = () => {
+  const storage = createMemoryStorage();
+  const app = createApp({
+    storage,
+    tokenSecret: TOKEN_SECRET,
+    encryptionSecret: "test-encryption-secret",
+  });
+  return { app, storage };
+};
+
+const asBearer = (token) => ({ authorization: `Bearer ${token}` });
+
+const signup = async (app, { email, firstName, lastName }) => {
+  const result = await app.handle({
+    method: "POST",
+    path: "/api/auth/signup",
+    body: { email, password: "pw-123456", firstName, lastName },
+  });
+  assert.equal(result.status, 201);
+  return result.body;
+};
+
+const me = (app, token) =>
+  app.handle({ method: "GET", path: "/api/me", headers: asBearer(token) });
+
+const blockMember = (app, token, userId) =>
+  app.handle({
+    method: "POST",
+    path: `/api/party/members/${userId}/block`,
+    headers: asBearer(token),
+    body: {},
+  });
+
+const cancelParty = (app, token) =>
+  app.handle({
+    method: "POST",
+    path: "/api/party/cancel",
+    headers: asBearer(token),
+    body: {},
+  });
+
+const getBackup = (app, token) =>
+  app.handle({
+    method: "GET",
+    path: "/api/party/backup",
+    headers: asBearer(token),
+  });
+
+const putBackup = (app, token) =>
+  app.handle({
+    method: "PUT",
+    path: "/api/party/backup",
+    headers: asBearer(token),
+    body: { baseVersion: null, envelope: {} },
+  });
+
+// Jane organizes a party and Tom joins it via a real invitation.
+const setupParty = async (app) => {
+  const jane = await signup(app, {
+    email: "jane@example.com",
+    firstName: "Jane",
+    lastName: "Doe",
+  });
+  const created = await app.handle({
+    method: "POST",
+    path: "/api/party",
+    headers: asBearer(jane.token),
+  });
+  assert.equal(created.status, 201);
+  const invited = await app.handle({
+    method: "POST",
+    path: "/api/party/invitations",
+    headers: asBearer(jane.token),
+    body: { password: "invite-pass" },
+  });
+  const tom = await signup(app, {
+    email: "tom@example.com",
+    firstName: "Tom",
+    lastName: "Doe",
+  });
+  const joined = await app.handle({
+    method: "POST",
+    path: "/api/party/join",
+    headers: asBearer(tom.token),
+    body: { code: invited.body.code, password: "invite-pass" },
+  });
+  assert.equal(joined.status, 200);
+  return { jane, tom, partyId: created.body.party.id };
+};
+
+test("organizer blocks a member: flagged, kept in the list, youAreBlocked on /me", async () => {
+  const { app } = makeApp();
+  const { jane, tom, partyId } = await setupParty(app);
+
+  const blocked = await blockMember(app, jane.token, tom.user.id);
+  assert.equal(blocked.status, 200);
+  const tomRow = blocked.body.party.members.find(
+    (member) => member.id === tom.user.id
+  );
+  assert.equal(tomRow.blocked, true);
+
+  // The blocked member still sees the party on /me, flagged (AC-2.9).
+  const tomMe = await me(app, tom.token);
+  assert.equal(tomMe.body.party.id, partyId);
+  assert.equal(tomMe.body.party.youAreBlocked, true);
+
+  // Unknown target → 404; the organizer can't block themself → 400.
+  assert.equal((await blockMember(app, jane.token, "nobody")).status, 404);
+  const selfBlock = await blockMember(app, jane.token, jane.user.id);
+  assert.equal(selfBlock.status, 400);
+});
+
+test("non-organizer block/cancel → 403 NOT_ORGANIZER (AC-2.12)", async () => {
+  const { app } = makeApp();
+  const { jane, tom } = await setupParty(app);
+
+  const blockAttempt = await blockMember(app, tom.token, jane.user.id);
+  assert.equal(blockAttempt.status, 403);
+  assert.equal(blockAttempt.body.error.code, "NOT_ORGANIZER");
+
+  const cancelAttempt = await cancelParty(app, tom.token);
+  assert.equal(cancelAttempt.status, 403);
+  assert.equal(cancelAttempt.body.error.code, "NOT_ORGANIZER");
+});
+
+test("organizer cancels the party: canceled on both members' /me (AC-2.10)", async () => {
+  const { app } = makeApp();
+  const { jane, tom } = await setupParty(app);
+
+  const canceled = await cancelParty(app, jane.token);
+  assert.equal(canceled.status, 200);
+  assert.equal(canceled.body.party.canceled, true);
+
+  assert.equal((await me(app, jane.token)).body.party.canceled, true);
+  assert.equal((await me(app, tom.token)).body.party.canceled, true);
+});
+
+test("blocked member gets 403 BLOCKED on backup GET and PUT (EC-9)", async () => {
+  const { app } = makeApp();
+  const { jane, tom } = await setupParty(app);
+  await blockMember(app, jane.token, tom.user.id);
+
+  const download = await getBackup(app, tom.token);
+  assert.equal(download.status, 403);
+  assert.equal(download.body.error.code, "BLOCKED");
+
+  const upload = await putBackup(app, tom.token);
+  assert.equal(upload.status, 403);
+  assert.equal(upload.body.error.code, "BLOCKED");
+
+  // The organizer still passes the enforcement layer (404 NO_BACKUP is
+  // the correct contract answer while no backup exists).
+  const organizerDownload = await getBackup(app, jane.token);
+  assert.equal(organizerDownload.status, 404);
+  assert.equal(organizerDownload.body.error.code, "NO_BACKUP");
+});
+
+test("canceled party gets 410 PARTY_CANCELED on backup GET and PUT", async () => {
+  const { app } = makeApp();
+  const { jane, tom } = await setupParty(app);
+  await cancelParty(app, jane.token);
+
+  for (const token of [jane.token, tom.token]) {
+    const download = await getBackup(app, token);
+    assert.equal(download.status, 410);
+    assert.equal(download.body.error.code, "PARTY_CANCELED");
+    const upload = await putBackup(app, token);
+    assert.equal(upload.status, 410);
+    assert.equal(upload.body.error.code, "PARTY_CANCELED");
+  }
+});
+
+test("blocked or canceled users are free to create/join a new party (DESIGN 3.6)", async () => {
+  const { app } = makeApp();
+  const { jane, tom } = await setupParty(app);
+  await blockMember(app, jane.token, tom.user.id);
+
+  // Blocked Tom can start his own party; his member record stays behind.
+  const tomParty = await app.handle({
+    method: "POST",
+    path: "/api/party",
+    headers: asBearer(tom.token),
+  });
+  assert.equal(tomParty.status, 201);
+  assert.equal(tomParty.body.party.name, "Tom's Party");
+  const janeParty = (await me(app, jane.token)).body.party;
+  assert.ok(
+    janeParty.members.some(
+      (member) => member.id === tom.user.id && member.blocked
+    )
+  );
+
+  // Jane cancels hers, then can join Tom's via a fresh invitation.
+  await cancelParty(app, jane.token);
+  const invited = await app.handle({
+    method: "POST",
+    path: "/api/party/invitations",
+    headers: asBearer(tom.token),
+    body: { password: "new-pass" },
+  });
+  const joined = await app.handle({
+    method: "POST",
+    path: "/api/party/join",
+    headers: asBearer(jane.token),
+    body: { code: invited.body.code, password: "new-pass" },
+  });
+  assert.equal(joined.status, 200);
+  assert.equal(joined.body.party.id, tomParty.body.party.id);
+});
+
+test("block and cancel mutate only the party record — never user or backup data (AC-2.9)", async () => {
+  const { app, storage } = makeApp();
+  const { jane, tom, partyId } = await setupParty(app);
+
+  // Simulate PR 4's future backup object plus the current user records.
+  await storage.writeJsonVersioned(
+    `parties/${partyId}.backup`,
+    { uploadedBy: tom.user.id, envelope: { data: "tom's entries" } },
+    { expectedVersion: null }
+  );
+  const backupBefore = await storage.readJsonVersioned(
+    `parties/${partyId}.backup`
+  );
+  const tomUserBefore = await storage.readJson(`user-ids/${tom.user.id}`);
+
+  await blockMember(app, jane.token, tom.user.id);
+  await cancelParty(app, jane.token);
+
+  // The backup (the blocked member's already-synced entries) and the user
+  // pointer records are byte-identical; only the party record changed.
+  assert.deepEqual(
+    await storage.readJsonVersioned(`parties/${partyId}.backup`),
+    backupBefore
+  );
+  assert.deepEqual(
+    await storage.readJson(`user-ids/${tom.user.id}`),
+    tomUserBefore
+  );
+  const party = (await storage.readJsonVersioned(`parties/${partyId}`)).value;
+  assert.equal(party.canceled, true);
+  assert.ok(
+    party.members.some((member) => member.id === tom.user.id && member.blocked)
+  );
+});

--- a/src/components/Party/MemberRow.tsx
+++ b/src/components/Party/MemberRow.tsx
@@ -1,18 +1,23 @@
 import React from "react";
+import { Button } from "react-bootstrap";
 import { PartyMember } from "../../services/syncApi/contract";
 
 interface MemberRowProps {
   member: PartyMember;
   isSelf: boolean;
   isOrganizer: boolean;
+  // Present only when the viewer may block this member (organizer viewing
+  // an active, non-self row — AC-2.12); the parent owns the confirm.
+  onBlock?: () => void;
 }
 
 /**
  * One static row of the party member list (DESIGN §3.2): name/email plus a
- * right-aligned status — an Organizer badge, a muted "Blocked" label, or
- * nothing. The organizer's Block button joins in the party-management PR.
+ * right-aligned status — an Organizer badge, a Block button (organizer
+ * view, AC-2.9), a muted "Blocked" label, or nothing. There is no
+ * un-block affordance — out of scope by design.
  */
-const MemberRow = ({ member, isSelf, isOrganizer }: MemberRowProps) => (
+const MemberRow = ({ member, isSelf, isOrganizer, onBlock }: MemberRowProps) => (
   <li className="member-row">
     <div className="member-row__identity">
       <span className="member-row__name">
@@ -24,6 +29,16 @@ const MemberRow = ({ member, isSelf, isOrganizer }: MemberRowProps) => (
     {isOrganizer && <span className="member-row__badge">Organizer</span>}
     {!isOrganizer && member.blocked && (
       <span className="member-row__blocked">Blocked</span>
+    )}
+    {!isOrganizer && !member.blocked && onBlock && (
+      <Button
+        variant="secondary"
+        className="member-row__block"
+        aria-label={`Block ${member.firstName} ${member.lastName}`}
+        onClick={onBlock}
+      >
+        Block
+      </Button>
     )}
   </li>
 );

--- a/src/components/Party/index.tsx
+++ b/src/components/Party/index.tsx
@@ -6,11 +6,16 @@ import { MainContentContainer } from "../common/MainContentContainer";
 import ButtonLikeLink from "../common/ButtonLikeLink";
 import MemberRow from "./MemberRow";
 import {
+  blockMember,
+  cancelParty,
   createParty,
   refreshMe,
 } from "../../redux/syncManager/actionCreators";
 import { SyncSession } from "../../services/session";
-import { Party as PartyShape } from "../../services/syncApi/contract";
+import {
+  Party as PartyShape,
+  PartyMember,
+} from "../../services/syncApi/contract";
 import "./styles.scss";
 
 interface PartyProps {
@@ -19,17 +24,29 @@ interface PartyProps {
   partyLoaded: boolean;
   onRefreshMe: () => void;
   onCreateParty: () => Promise<PartyShape>;
+  onBlockMember: (payload: { userId: string }) => Promise<PartyShape>;
+  onCancelParty: () => Promise<PartyShape>;
 }
 
-// DESIGN §3.1 — logged in, no party yet: create or join.
+// DESIGN §3.1 — logged in, no party yet: create or join. Also the shell
+// for the blocked/canceled views (DESIGN §3.6), which reuse this CTA
+// layout with a status line on top — both states leave the user free to
+// create/join elsewhere.
 const NoPartyView = ({
   onCreateClick,
   error,
+  statusLine,
 }: {
   onCreateClick: () => void;
   error: string | null;
+  statusLine?: string;
 }) => (
   <React.Fragment>
+    {statusLine && (
+      <p className="party-card__status" role="status">
+        {statusLine}
+      </p>
+    )}
     <div className="party-card">
       <h2 className="party-card__title">Create a party</h2>
       <p className="party-card__description">
@@ -62,13 +79,19 @@ const NoPartyView = ({
 );
 
 // DESIGN §3.2/§3.3 — the party detail: member list for everyone,
-// organizer-only actions (AC-2.12). Block/Cancel land in the next PR.
+// organizer-only actions (AC-2.12).
 const PartyDetailView = ({
   party,
   selfId,
+  error,
+  onBlockClick,
+  onCancelClick,
 }: {
   party: PartyShape;
   selfId: string;
+  error: string | null;
+  onBlockClick: (member: PartyMember) => void;
+  onCancelClick: () => void;
 }) => {
   const isOrganizer = party.organizerId === selfId;
   const organizer = party.members.find(
@@ -87,20 +110,43 @@ const PartyDetailView = ({
             member={member}
             isSelf={member.id === selfId}
             isOrganizer={member.id === party.organizerId}
+            onBlock={
+              // AC-2.12: only the organizer blocks; never self.
+              isOrganizer && member.id !== selfId
+                ? () => onBlockClick(member)
+                : undefined
+            }
           />
         ))}
       </ul>
+      {error && (
+        <p
+          className="restore-backup-error text-danger vertical-standard-space"
+          role="alert"
+        >
+          {error}
+        </p>
+      )}
       {isOrganizer && party.members.length === 1 && (
         <p className="party-card__hint text-secondary">
           Invite family members to start syncing.
         </p>
       )}
       {isOrganizer ? (
-        <ButtonLikeLink
-          className="btn-primary"
-          to="/party/invite"
-          buttonTitle="Add a member"
-        />
+        <React.Fragment>
+          <ButtonLikeLink
+            className="btn-primary"
+            to="/party/invite"
+            buttonTitle="Add a member"
+          />
+          <Button
+            variant="danger"
+            className="full-width vertical-standard-space"
+            onClick={onCancelClick}
+          >
+            Cancel party
+          </Button>
+        </React.Fragment>
       ) : (
         <p className="party-card__hint text-secondary">
           Only {organizer ? organizer.firstName : "the organizer"}, the
@@ -112,9 +158,10 @@ const PartyDetailView = ({
 };
 
 /**
- * Party hub (DESIGN §3): renders the no-party, organizer or member view.
- * Membership is refreshed from GET /me on mount (RFC §2.2 — never cached
- * as authoritative).
+ * Party hub (DESIGN §3): renders the no-party, organizer, member, blocked
+ * or canceled view. Membership is refreshed from GET /me on mount
+ * (RFC §2.2 — never cached as authoritative), which is what re-renders
+ * the blocked/canceled states for affected members.
  */
 const Party = ({
   session,
@@ -122,6 +169,8 @@ const Party = ({
   partyLoaded,
   onRefreshMe,
   onCreateParty,
+  onBlockMember,
+  onCancelParty,
 }: PartyProps) => {
   const history = useHistory();
   const [error, setError] = useState<string | null>(null);
@@ -130,22 +179,43 @@ const Party = ({
     onRefreshMe();
   }, [onRefreshMe]);
 
-  const handleCreateParty = async () => {
+  const runWithErrorHandling = async (action: () => Promise<unknown>) => {
+    setError(null);
+    try {
+      await action();
+    } catch (actionError) {
+      setError((actionError as Error).message || "Something went wrong.");
+      // A stale tab may have missed a membership change — refresh.
+      onRefreshMe();
+    }
+  };
+
+  const handleCreateParty = () => {
     // Same confirm pattern as "Clear all data" (DESIGN §3.1, AC-2.1).
     const confirmed = window.confirm(
       "Create a party? You'll become its organizer and can invite family members."
     );
     if (!confirmed) return;
-    setError(null);
-    try {
-      await onCreateParty();
-    } catch (createError) {
-      setError(
-        (createError as Error).message || "Could not create the party."
-      );
-      // A stale tab may have missed a membership change — refresh.
-      onRefreshMe();
-    }
+    runWithErrorHandling(onCreateParty);
+  };
+
+  // AC-2.9 — blocking is guarded by a confirm carrying the consequences.
+  const handleBlockClick = (member: PartyMember) => {
+    const confirmed = window.confirm(
+      `Block ${member.firstName} ${member.lastName}? They'll immediately lose the ability to sync. Entries they've already contributed stay in the party's history.`
+    );
+    if (!confirmed) return;
+    runWithErrorHandling(() => onBlockMember({ userId: member.id }));
+  };
+
+  // AC-2.10 — canceling is guarded the same way.
+  const handleCancelClick = () => {
+    if (!party) return;
+    const confirmed = window.confirm(
+      `Cancel ${party.name}? No member will be able to sync afterward. Nobody's local data is deleted.`
+    );
+    if (!confirmed) return;
+    runWithErrorHandling(onCancelParty);
   };
 
   return (
@@ -161,8 +231,28 @@ const Party = ({
             buttonTitle="Go to Account"
           />
         </div>
+      ) : party && party.youAreBlocked ? (
+        // DESIGN §3.6 — blocked members see the no-party CTA layout.
+        <NoPartyView
+          onCreateClick={handleCreateParty}
+          error={error}
+          statusLine="You've been removed from this party by its organizer."
+        />
+      ) : party && party.canceled ? (
+        // DESIGN §3.6 — members of a canceled party likewise.
+        <NoPartyView
+          onCreateClick={handleCreateParty}
+          error={error}
+          statusLine="Your party was canceled. Create or join a new one to sync again."
+        />
       ) : party ? (
-        <PartyDetailView party={party} selfId={session.user.id} />
+        <PartyDetailView
+          party={party}
+          selfId={session.user.id}
+          error={error}
+          onBlockClick={handleBlockClick}
+          onCancelClick={handleCancelClick}
+        />
       ) : partyLoaded ? (
         <NoPartyView onCreateClick={handleCreateParty} error={error} />
       ) : (
@@ -190,6 +280,8 @@ const mapStateToProps = (state: any) => ({
 const mapActionsToProps = (dispatch: any) => ({
   onRefreshMe: () => dispatch(refreshMe()),
   onCreateParty: () => dispatch(createParty()),
+  onBlockMember: (payload: { userId: string }) => dispatch(blockMember(payload)),
+  onCancelParty: () => dispatch(cancelParty()),
 });
 
 export default connect(mapStateToProps, mapActionsToProps)(Party);

--- a/src/components/Party/styles.scss
+++ b/src/components/Party/styles.scss
@@ -51,6 +51,14 @@
     }
   }
 
+  // Status line above the blocked/canceled CTA layout (DESIGN §3.6).
+  .party-card__status {
+    color: $text-primary;
+    font-size: 0.88rem;
+    line-height: 1.5;
+    margin: $vertical-standard-margin 0 0;
+  }
+
   .member-row {
     display: flex;
     align-items: center;
@@ -96,6 +104,18 @@
       color: $text-muted;
       font-size: 0.8rem;
       flex: 0 0 auto;
+    }
+
+    // Compact next to the row, overriding the global 3.1em .btn height.
+    .member-row__block {
+      height: 2.2em;
+      padding: 0 0.9rem;
+      font-size: 0.8rem;
+      flex: 0 0 auto;
+
+      &:focus-visible {
+        @include focus-ring();
+      }
     }
   }
 

--- a/src/integrationTests/helpers/fakeSyncServer.ts
+++ b/src/integrationTests/helpers/fakeSyncServer.ts
@@ -40,9 +40,13 @@ export interface FakeSyncServer {
   loginAs: (email: string) => SyncSession;
   /**
    * Creates a party with already-seeded users: the first email becomes the
-   * organizer, the rest join as members. Returns the party id.
+   * organizer, the rest join as members. Options seed pre-blocked members
+   * (by email) or a canceled party. Returns the party id.
    */
-  seedPartyWithMembers: (emails: string[]) => string;
+  seedPartyWithMembers: (
+    emails: string[],
+    options?: { blocked?: string[]; canceled?: boolean }
+  ) => string;
   /** Adds a redeemable invitation to the seeded party; returns the code. */
   seedInvitation: (options: { password: string; used?: boolean }) => string;
   /**
@@ -201,6 +205,18 @@ export const installFakeSyncServer = (): FakeSyncServer => {
   const unauthorized = () =>
     errorResponse(401, "UNAUTHORIZED", "You need to sign in again.");
 
+  // Like the real server (DESIGN §3.6): blocked members and members of
+  // canceled parties are free to create/join elsewhere; only an active
+  // membership blocks it.
+  const hasActiveMembership = (user: FakeUserRecord): boolean => {
+    const party = parties.find((candidate) => candidate.id === user.partyId);
+    if (!party || party.canceled) return false;
+    const member = party.memberIds.find(
+      (candidate) => candidate.id === user.id
+    );
+    return !(member && member.blocked);
+  };
+
   const handle = (
     method: string,
     path: string,
@@ -253,7 +269,7 @@ export const installFakeSyncServer = (): FakeSyncServer => {
     if (method === "POST" && path === "/api/party") {
       const user = authenticate(headers);
       if (!user) return unauthorized();
-      if (user.partyId)
+      if (hasActiveMembership(user))
         return errorResponse(
           409,
           "ALREADY_IN_PARTY",
@@ -299,8 +315,9 @@ export const installFakeSyncServer = (): FakeSyncServer => {
           "VALIDATION_ERROR",
           "An invitation code and password are required."
         );
-      // EC-6 first: an existing membership never consumes the invitation.
-      if (user.partyId)
+      // EC-6 first: an existing (active) membership never consumes the
+      // invitation; blocked/canceled users may join elsewhere.
+      if (hasActiveMembership(user))
         return errorResponse(
           409,
           "ALREADY_IN_PARTY",
@@ -334,8 +351,60 @@ export const installFakeSyncServer = (): FakeSyncServer => {
           "That password doesn't match this invitation."
         );
       invitation.used = true;
-      party.memberIds.push({ id: user.id, blocked: false });
+      // Re-invited past member: refresh the existing record, no duplicate.
+      const existing = party.memberIds.find(
+        (candidate) => candidate.id === user.id
+      );
+      if (existing) existing.blocked = false;
+      else party.memberIds.push({ id: user.id, blocked: false });
       user.partyId = party.id;
+      return jsonResponse(200, { party: publicParty(party, user.id) });
+    }
+
+    // RFC §3.7 — organizer blocks a member (AC-2.9).
+    const blockMatch = /^\/api\/party\/members\/([^/]+)\/block$/.exec(path);
+    if (method === "POST" && blockMatch) {
+      const user = authenticate(headers);
+      if (!user) return unauthorized();
+      const party = parties.find((candidate) => candidate.id === user.partyId);
+      if (!party)
+        return errorResponse(404, "NO_PARTY", "You don't belong to a party.");
+      if (party.organizerId !== user.id)
+        return errorResponse(
+          403,
+          "NOT_ORGANIZER",
+          "Only the organizer can block members."
+        );
+      const targetId = decodeURIComponent(blockMatch[1]);
+      if (targetId === party.organizerId)
+        return errorResponse(
+          400,
+          "VALIDATION_ERROR",
+          "The organizer cannot be blocked."
+        );
+      const target = party.memberIds.find(
+        (candidate) => candidate.id === targetId
+      );
+      if (!target)
+        return errorResponse(404, "NOT_FOUND", "That member isn't in your party.");
+      target.blocked = true;
+      return jsonResponse(200, { party: publicParty(party, user.id) });
+    }
+
+    // RFC §3.8 — organizer cancels the party (AC-2.10).
+    if (method === "POST" && path === "/api/party/cancel") {
+      const user = authenticate(headers);
+      if (!user) return unauthorized();
+      const party = parties.find((candidate) => candidate.id === user.partyId);
+      if (!party)
+        return errorResponse(404, "NO_PARTY", "You don't belong to a party.");
+      if (party.organizerId !== user.id)
+        return errorResponse(
+          403,
+          "NOT_ORGANIZER",
+          "Only the organizer can cancel the party."
+        );
+      party.canceled = true;
       return jsonResponse(200, { party: publicParty(party, user.id) });
     }
 
@@ -383,14 +452,18 @@ export const installFakeSyncServer = (): FakeSyncServer => {
       setSession(session);
       return session;
     },
-    seedPartyWithMembers: (emails) => {
+    seedPartyWithMembers: (emails, { blocked = [], canceled = false } = {}) => {
       const [organizerEmail, ...memberEmails] = emails;
       const party = createPartyRecord(mustFindByEmail(organizerEmail));
       memberEmails.forEach((email) => {
         const member = mustFindByEmail(email);
-        party.memberIds.push({ id: member.id, blocked: false });
+        party.memberIds.push({
+          id: member.id,
+          blocked: blocked.includes(email),
+        });
         member.partyId = party.id;
       });
+      party.canceled = canceled;
       return party.id;
     },
     seedInvitation: ({ password, used = false }) => {

--- a/src/integrationTests/partyManagement.test.tsx
+++ b/src/integrationTests/partyManagement.test.tsx
@@ -1,0 +1,183 @@
+import { screen } from "@testing-library/react";
+import { renderApp } from "./helpers/renderApp";
+import {
+  installFakeSyncServer,
+  FakeSyncServer,
+} from "./helpers/fakeSyncServer";
+
+/**
+ * Integration tests for party management (multi-user sync PR 3): blocking
+ * a member, canceling the party, and how those states render for the
+ * affected users (AC-2.9, AC-2.10, AC-2.12, DESIGN §3.2/§3.6). All
+ * network traffic goes through the in-memory fakeSyncServer.
+ */
+
+const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
+
+let server: FakeSyncServer;
+let confirmSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.useFakeTimers();
+  jest.setSystemTime(PINNED_DATE);
+  server = installFakeSyncServer();
+  confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+});
+
+afterEach(() => {
+  confirmSpy.mockRestore();
+  server.restore();
+  jest.useRealTimers();
+});
+
+const jane = {
+  email: "jane@example.com",
+  password: "hunter22!",
+  firstName: "Jane",
+  lastName: "Doe",
+};
+const tom = {
+  email: "tom@example.com",
+  password: "hunter33!",
+  firstName: "Tom",
+  lastName: "Doe",
+};
+
+const seedJaneAndTom = (options?: {
+  blocked?: string[];
+  canceled?: boolean;
+}) => {
+  server.seedUser(jane);
+  server.seedUser(tom);
+  server.seedPartyWithMembers([jane.email, tom.email], options);
+};
+
+describe("blocking a member", () => {
+  it("organizer confirms a block and the row flips to Blocked (AC-2.9)", async () => {
+    seedJaneAndTom();
+    const session = server.loginAs(jane.email);
+    const { user } = await renderApp("/party", { session });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Block Tom Doe" })
+    );
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      "Block Tom Doe? They'll immediately lose the ability to sync. Entries they've already contributed stay in the party's history."
+    );
+    // The row shows the muted Blocked label; the Block button is gone.
+    expect(await screen.findByText("Blocked")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Block Tom Doe" })
+    ).not.toBeInTheDocument();
+    // Tom stays in the list (nothing is retroactively removed).
+    expect(screen.getByText(/Tom Doe/)).toBeInTheDocument();
+  });
+
+  it("a dismissed confirm blocks nobody", async () => {
+    confirmSpy.mockReturnValue(false);
+    seedJaneAndTom();
+    const session = server.loginAs(jane.email);
+    const { user } = await renderApp("/party", { session });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Block Tom Doe" })
+    );
+
+    expect(screen.queryByText("Blocked")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Block Tom Doe" })
+    ).toBeInTheDocument();
+  });
+
+  it("a blocked user sees the removed-from-party view with create/join open (DESIGN 3.6)", async () => {
+    seedJaneAndTom({ blocked: [tom.email] });
+    const session = server.loginAs(tom.email);
+    await renderApp("/party", { session });
+
+    expect(
+      await screen.findByText(
+        "You've been removed from this party by its organizer."
+      )
+    ).toBeInTheDocument();
+    // The member list is gone; the user is free to start over.
+    expect(screen.queryByText("Jane's Party")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create a party" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Join a party" })
+    ).toBeInTheDocument();
+  });
+});
+
+describe("canceling the party", () => {
+  it("organizer confirms the cancel and sees the canceled view (AC-2.10)", async () => {
+    seedJaneAndTom();
+    const session = server.loginAs(jane.email);
+    const { user } = await renderApp("/party", { session });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Cancel party" })
+    );
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      "Cancel Jane's Party? No member will be able to sync afterward. Nobody's local data is deleted."
+    );
+    expect(
+      await screen.findByText(
+        "Your party was canceled. Create or join a new one to sync again."
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Jane's Party")).not.toBeInTheDocument();
+  });
+
+  it("a member of a canceled party sees the same canceled view", async () => {
+    seedJaneAndTom({ canceled: true });
+    const session = server.loginAs(tom.email);
+    await renderApp("/party", { session });
+
+    expect(
+      await screen.findByText(
+        "Your party was canceled. Create or join a new one to sync again."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create a party" })
+    ).toBeInTheDocument();
+  });
+});
+
+describe("organizer-only visibility (AC-2.12)", () => {
+  it("a member sees neither Block buttons nor Cancel party", async () => {
+    seedJaneAndTom();
+    const session = server.loginAs(tom.email);
+    await renderApp("/party", { session });
+
+    expect(await screen.findByText("Jane's Party")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^Block / })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Cancel party" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Add a member" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("the organizer has no Block button on their own row", async () => {
+    seedJaneAndTom();
+    const session = server.loginAs(jane.email);
+    await renderApp("/party", { session });
+
+    expect(await screen.findByText("Jane's Party")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Block Jane Doe" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Block Tom Doe" })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/redux/syncManager/actionCreators.ts
+++ b/src/redux/syncManager/actionCreators.ts
@@ -104,3 +104,30 @@ export const joinParty =
     setParty(dispatch, party);
     return party;
   };
+
+// AC-2.9: blocks a member (organizer only). The member keeps their record
+// — and their already-synced entries — but immediately loses sync access.
+export const blockMember =
+  ({ userId }: { userId: string }) =>
+  async (dispatch: Dispatch): Promise<Party> => {
+    const session = getSession();
+    if (!session) throw new Error("Not signed in");
+    const { party } = await syncApi.blockMember({
+      token: session.token,
+      userId,
+    });
+    setParty(dispatch, party);
+    return party;
+  };
+
+// AC-2.10: cancels the party (organizer only). Nobody's local data is
+// touched; the canceled state re-renders for every member on /me refresh.
+export const cancelParty =
+  () =>
+  async (dispatch: Dispatch): Promise<Party> => {
+    const session = getSession();
+    if (!session) throw new Error("Not signed in");
+    const { party } = await syncApi.cancelParty({ token: session.token });
+    setParty(dispatch, party);
+    return party;
+  };

--- a/src/services/syncApi/contract.ts
+++ b/src/services/syncApi/contract.ts
@@ -14,6 +14,8 @@ export const SYNC_ERROR_CODES = {
   INVITATION_NOT_FOUND: "INVITATION_NOT_FOUND",
   INVITATION_WRONG_PASSWORD: "INVITATION_WRONG_PASSWORD",
   INVITATION_USED: "INVITATION_USED",
+  BLOCKED: "BLOCKED",
+  NO_BACKUP: "NO_BACKUP",
   // 409 when the server exhausts its CAS retry on a concurrent update.
   CONFLICT: "CONFLICT",
   // Used by the client for transport-level failures (server unreachable).

--- a/src/services/syncApi/index.ts
+++ b/src/services/syncApi/index.ts
@@ -116,3 +116,26 @@ export const joinParty = ({
     body: { code, password },
     token,
   });
+
+export const blockMember = ({
+  token,
+  userId,
+}: {
+  token: string;
+  userId: string;
+}): Promise<PartyResponse> =>
+  request<PartyResponse>(
+    `/api/party/members/${encodeURIComponent(userId)}/block`,
+    { method: "POST", body: {}, token }
+  );
+
+export const cancelParty = ({
+  token,
+}: {
+  token: string;
+}): Promise<PartyResponse> =>
+  request<PartyResponse>("/api/party/cancel", {
+    method: "POST",
+    body: {},
+    token,
+  });


### PR DESCRIPTION
Third of six stacked PRs for multi-user sync (`docs/multi-user-sync/TASKS.md` PR 3; RFC §3.7–3.8; DESIGN §3.2/§3.6; PRD AC-2.9–2.12, EC-9).

## What this adds
- **Server**: `POST /api/party/members/{userId}/block` (organizer-only, member record kept and flagged, self/unknown rejected) and `POST /api/party/cancel` (organizer-only). A shared `requirePartyAccess` enforcement layer now resolves UNAUTHORIZED / NO_PARTY / 403 BLOCKED / 410 PARTY_CANCELED for anything touching party data — the backup GET/PUT routes already pass through it, so PR 4's sync endpoints inherit blocked/canceled enforcement (Tech Lead carry-forward). Blocked/canceled users can create or join a new party (membership test is for an *active* party); old member records stay behind per AC-2.9.
- **Client**: Block button on member rows (organizer view only, never self, confirm dialog) flipping to the "Blocked" label; "Cancel party" danger action with confirm; `/party` blocked/canceled stale-state views with exact design copy; `blockMember`/`cancelParty` in syncApi/syncManager; `BLOCKED`/`NO_BACKUP` added to the client error contract in lockstep with the server.
- **Tests**: 7 new server contract tests — including the QA-requested assertion that block/cancel mutate only party records, leaving backup and user data byte-identical (AC-2.9) — and 7 new integration tests; fakeSyncServer mirrors block/cancel with `{blocked, canceled}` seed options.

## Verification
- Server contract tests: 22/22; integration: 92/92 (14 suites; existing tests unmodified); typecheck clean; lint clean on touched files
- Real-server smoke: member-block 403 → block → `youAreBlocked` → backup GET 403 BLOCKED → cancel → 410 PARTY_CANCELED → blocked user creates a new party
- Version 1.4.0 + CHANGELOG

## Noted deviations
- `PUT /api/party/backup` is a temporary `501 NOT_IMPLEMENTED` stub behind the enforcement layer (replaced in PR 4).
- Blocked-vs-canceled precedence: `youAreBlocked` wins as the more specific state.
- DESIGN §4.2 sync-card banners land with the sync card itself in PR 4; this PR provides their server-side semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XK2sxKjRfUxBMqyQHypqLB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XK2sxKjRfUxBMqyQHypqLB)_