### PR TITLE
QA round-1 fixes: category sync, grouped wizard cards, review cleanup (PR 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.2] - 2026-07-13
+
+### Fixed
+- Multi-user sync QA round 1: user-created categories now travel through
+  sync (AC-3.10). Both upload paths — the silent local-only upload and
+  the reviewed merge — write an additive, case-insensitive union of the
+  local and remote category lists (excluding names already promoted to
+  buckets), so a member's custom category is never dropped from the party
+  backup and reaches every member. `snapshotsContentEqual` compares
+  categories case-insensitively so two members with different casings
+  converge to "You're up to date." instead of re-uploading forever
+- Review wizard: a brand-new fixed entry or bucket arriving with several
+  pending history states now shows ONE card per definition (RFC §4.1),
+  fronted by the resolved current state; one decision applies to every
+  pending state and a rejection records a per-state `(key, hash)` entry
+  for the whole group
+- Review wizard: navigating away mid-review now clears the staged review,
+  so a later direct visit to `/sync-review` finds nothing to review
+  (DESIGN §4.3) — internal phase changes and the already-cleared
+  cancel/success/declined flows stay unaffected
+- Review wizard: action button aria-labels keep the contributor's name
+  casing ("…added by Tom", not "…added by tom")
+- Data Management sync card no longer updates its state after navigating
+  to the review wizard, removing an act()/unmounted-update warning
+
 ## [1.6.1] - 2026-07-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/src/components/SyncReview/index.tsx
+++ b/src/components/SyncReview/index.tsx
@@ -70,6 +70,15 @@ const SyncReview = ({
   const [isDone, setIsDone] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
 
+  // DESIGN §4.3: navigating away mid-review IS a cancel. Unmounting
+  // drops the staged download so a later direct visit to /sync-review
+  // finds nothing to review. Internal phase changes (item → summary →
+  // success) never unmount, and the flows that already cleared
+  // (cancel/success/declined) make this a no-op.
+  const clearOnUnmountRef = useRef(onClearPendingReview);
+  clearOnUnmountRef.current = onClearPendingReview;
+  useEffect(() => () => clearOnUnmountRef.current(), []);
+
   const items = pendingReview ? pendingReview.items : [];
   const remaining = items.filter((item) => !decisions[item.key]);
   const currentItem = remaining[0];
@@ -150,12 +159,35 @@ const SyncReview = ({
   const handleUpload = async () => {
     if (!pendingReview) return;
     const decided = items.map((item) => decisions[item.key]);
-    const acceptedItems = decided
+    // A grouped card (brand-new fixed entry/bucket, RFC §4.1) expands to
+    // its member states: one decision applies — and one rejection
+    // records — all of them. A modified representative replaces its own
+    // member state; the other states go up as reviewed.
+    const acceptedItems: IncomingItem[] = [];
+    decided
       .filter((decision) => decision.action === "accept")
-      .map((decision) => decision.item);
-    const rejectedItems = decided
+      .forEach((decision) => {
+        const item = decision.item;
+        if (!item.grouped) {
+          acceptedItems.push(item);
+          return;
+        }
+        item.grouped.forEach((member) => {
+          acceptedItems.push(
+            member.key === item.key
+              ? ({ ...item, grouped: undefined } as IncomingItem)
+              : (member as IncomingItem)
+          );
+        });
+      });
+    const rejectedItems: { key: string; hash: string }[] = [];
+    decided
       .filter((decision) => decision.action === "reject")
-      .map((decision) => ({ key: decision.item.key, hash: decision.item.hash }));
+      .forEach((decision) => {
+        (decision.item.grouped || [decision.item]).forEach(({ key, hash }) => {
+          rejectedItems.push({ key, hash });
+        });
+      });
 
     setUploadState("uploading");
     try {

--- a/src/components/SyncReview/itemFacts.ts
+++ b/src/components/SyncReview/itemFacts.ts
@@ -36,6 +36,12 @@ const attributionText = (addedBy?: AddedBy): string =>
   // AC-1.6/AC-3.4 — legacy/unattributed items show the anonymous fallback.
   addedBy && addedBy.name ? `Added by ${addedBy.name}` : "Added anonymously";
 
+// Same attribution for the accessible action labels ("Accept $42.10
+// expense added by Tom"): lowercase phrasing, but the contributor's name
+// keeps its casing.
+const labelAttribution = (addedBy?: AddedBy): string =>
+  addedBy && addedBy.name ? `added by ${addedBy.name}` : "added anonymously";
+
 export const getItemFacts = (item: SyncItem): ItemFacts => {
   if (item.kind === "entry") {
     const entry = item.entry;
@@ -49,7 +55,7 @@ export const getItemFacts = (item: SyncItem): ItemFacts => {
       categories: prettyCategories(entry.categories_path),
       dateText: dayjs(entry.date).format("MMM D, YYYY"),
       attribution,
-      shortLabel: `${money(entry.amount)} ${kindLabel.toLowerCase()} ${attribution.toLowerCase()}`,
+      shortLabel: `${money(entry.amount)} ${kindLabel.toLowerCase()} ${labelAttribution(entry.addedBy)}`,
     };
   }
 
@@ -64,7 +70,7 @@ export const getItemFacts = (item: SyncItem): ItemFacts => {
         removed: true,
         dateText: `Removed from ${state.from}`,
         attribution,
-        shortLabel: `${kindLabel.toLowerCase()} removal ${attribution.toLowerCase()}`,
+        shortLabel: `${kindLabel.toLowerCase()} removal ${labelAttribution(state.addedBy)}`,
       };
     }
     return {
@@ -75,7 +81,7 @@ export const getItemFacts = (item: SyncItem): ItemFacts => {
       categories: prettyCategories(state.categories_path),
       dateText: `From ${state.from}`,
       attribution,
-      shortLabel: `${money(state.amount)} ${kindLabel.toLowerCase()} ${attribution.toLowerCase()}`,
+      shortLabel: `${money(state.amount)} ${kindLabel.toLowerCase()} ${labelAttribution(state.addedBy)}`,
     };
   }
 
@@ -89,6 +95,6 @@ export const getItemFacts = (item: SyncItem): ItemFacts => {
     dateText:
       state.from === "0000-00" ? "From the beginning" : `From ${state.from}`,
     attribution,
-    shortLabel: `${item.bucket!.name} bucket ${attribution.toLowerCase()}`,
+    shortLabel: `${item.bucket!.name} bucket ${labelAttribution(state.addedBy)}`,
   };
 };

--- a/src/components/common/ExpensesManager/DataManagement/SyncCard.tsx
+++ b/src/components/common/ExpensesManager/DataManagement/SyncCard.tsx
@@ -149,12 +149,16 @@ const SyncCard = ({
     try {
       const outcome = await onSync();
       if (outcome.type === "review") {
+        // Navigating away unmounts this card — no state updates after
+        // this point (a `finally` here would fire one on the unmounted
+        // component).
         history.push("/sync-review");
         return;
       }
       setStatus(
         outcome.type === "first-sync" ? COPY.firstSync : COPY.upToDate
       );
+      setIsSyncing(false);
     } catch (syncError) {
       if (isSyncApiError(syncError)) {
         if (syncError.code === SYNC_ERROR_CODES.BLOCKED) {
@@ -175,7 +179,6 @@ const SyncCard = ({
       } else {
         setAlert(COPY.connectionFailed);
       }
-    } finally {
       setIsSyncing(false);
     }
   };

--- a/src/helpers/syncMergeHelper/syncMergeHelper.test.ts
+++ b/src/helpers/syncMergeHelper/syncMergeHelper.test.ts
@@ -4,6 +4,7 @@ import {
   contentHash,
   diffSnapshots,
   extractItems,
+  mergeCategories,
   snapshotsContentEqual,
 } from "./syncMergeHelper";
 import { BackupData } from "../../services/syncApi/contract";
@@ -261,5 +262,135 @@ describe("applyItems (RFC §4.3 step 5)", () => {
       })
     );
     expect(merged.buckets).toEqual({ Pets: [{ from: "0000-00", limit: 50 }] });
+  });
+});
+
+describe("grouping brand-new definitions (RFC §4.1 — QA D2)", () => {
+  const multiStateRemote = (): BackupData => ({
+    ...({
+      balance: [],
+      buckets: {},
+      categories: [],
+      fixedEntries: [],
+    } as BackupData),
+    fixedEntries: [
+      {
+        id: "f-new",
+        type: "expense",
+        history: [
+          { from: "2026-01", amount: "9", description: "Netflix" },
+          { from: "2026-03", amount: "12", description: "Netflix 4K" },
+        ],
+      },
+    ],
+    buckets: {
+      Pets: [
+        { from: "0000-00", limit: 50 },
+        { from: "2026-06", limit: 80 },
+      ],
+    },
+  });
+
+  it("presents a brand-new multi-state fixed entry and bucket as ONE item each, fronted by the resolved current state", () => {
+    const incoming = diffSnapshots({
+      localData: emptyData(),
+      remoteData: multiStateRemote(),
+    });
+
+    expect(incoming).toHaveLength(2);
+    const [fixedCard, bucketCard] = incoming;
+    // Resolved current state = the latest by `from`.
+    expect(fixedCard.fixed!.state).toEqual({
+      from: "2026-03",
+      amount: "12",
+      description: "Netflix 4K",
+    });
+    expect(fixedCard.grouped).toHaveLength(2);
+    expect(bucketCard.bucket!.state).toEqual({ from: "2026-06", limit: 80 });
+    expect(bucketCard.grouped).toHaveLength(2);
+
+    // Accepting the card applies ALL its pending states.
+    const merged = applyItems(
+      emptyData(),
+      incoming.reduce<any[]>(
+        (all, item) => all.concat(item.grouped || [item]),
+        []
+      )
+    );
+    expect(merged.fixedEntries[0].history).toHaveLength(2);
+    expect(merged.buckets.Pets).toHaveLength(2);
+  });
+
+  it("keeps states of an already-known definition as individual items", () => {
+    const local: BackupData = {
+      ...emptyData(),
+      buckets: { Pets: [{ from: "0000-00", limit: 50 }] },
+    };
+    const incoming = diffSnapshots({
+      localData: local,
+      remoteData: multiStateRemote(),
+    });
+    // The known bucket's new state is its own item; the new fixed entry
+    // still groups.
+    const bucketItems = incoming.filter((item) => item.kind === "bucket");
+    expect(bucketItems).toHaveLength(1);
+    expect(bucketItems[0].grouped).toBeUndefined();
+    const fixedItems = incoming.filter((item) => item.kind === "fixed");
+    expect(fixedItems).toHaveLength(1);
+    expect(fixedItems[0].grouped).toHaveLength(2);
+  });
+
+  it("rejecting a group records one rejection per member state, suppressing every state on the next diff", () => {
+    const remote = multiStateRemote();
+    const incoming = diffSnapshots({
+      localData: emptyData(),
+      remoteData: remote,
+    });
+    // The wizard expands a rejected group into a (key, hash) per member —
+    // reproduce that here, then re-diff the same backup.
+    const rejections = incoming.reduce<{ [key: string]: string[] }>(
+      (memory, item) => {
+        (item.grouped || [item]).forEach(({ key, hash }) => {
+          memory[key] = [...(memory[key] || []), hash];
+        });
+        return memory;
+      },
+      {}
+    );
+
+    expect(
+      diffSnapshots({ localData: emptyData(), remoteData: remote, rejections })
+    ).toEqual([]);
+  });
+});
+
+describe("category merging (AC-3.10 — QA D1)", () => {
+  it("unions additively, case-insensitively, local casing and order first", () => {
+    expect(
+      mergeCategories({
+        localCategories: ["Pet Care", "gym"],
+        remoteCategories: ["pet care", "Travel Fund"],
+        buckets: {},
+      })
+    ).toEqual(["Pet Care", "gym", "Travel Fund"]);
+  });
+
+  it("excludes names promoted to buckets, matching bucket creation", () => {
+    expect(
+      mergeCategories({
+        localCategories: ["gym"],
+        remoteCategories: ["Pet Care"],
+        buckets: { "pet care": [{ from: "0000-00", limit: 50 }] },
+      })
+    ).toEqual(["gym"]);
+  });
+
+  it("content equality treats category casing case-insensitively (no ping-pong)", () => {
+    const a = { ...emptyData(), categories: ["Pet Care"] };
+    const b = { ...emptyData(), categories: ["pet care"] };
+    expect(snapshotsContentEqual(a, b)).toBe(true);
+    expect(
+      snapshotsContentEqual(a, { ...emptyData(), categories: [] })
+    ).toBe(false);
   });
 });

--- a/src/helpers/syncMergeHelper/syncMergeHelper.ts
+++ b/src/helpers/syncMergeHelper/syncMergeHelper.ts
@@ -27,6 +27,11 @@ export interface IncomingItem extends SyncItem {
   // True when the local snapshot has the same itemKey with different
   // content — an edit by another member, not a brand-new item.
   isChange: boolean;
+  // A brand-new fixed entry / bucket arriving with several pending
+  // history states presents as ONE card whose facts are the resolved
+  // current state (RFC §4.1); `grouped` carries every per-state item so
+  // one decision applies (and one rejection records) all of them.
+  grouped?: SyncItem[];
 }
 
 // Rejection memory (AC-3.9/EC-4): content hashes rejected per itemKey.
@@ -116,6 +121,70 @@ const itemHashByKey = (data: BackupData): Map<string, string> => {
   return map;
 };
 
+// Collapses the per-state items of BRAND-NEW fixed entries/buckets (no
+// local counterpart) into one reviewable item each (RFC §4.1): the
+// representative carries the resolved current state (the latest by
+// `from`) and `grouped` lists every member state. States of an already-
+// known definition stay individual items ("Tom raised the Groceries
+// bucket for August").
+const groupNewDefinitions = (
+  incoming: IncomingItem[],
+  localData: BackupData
+): IncomingItem[] => {
+  const localFixedIds = new Set(
+    (localData.fixedEntries || []).map((definition: any) => definition.id)
+  );
+  const localBucketNames = new Set(
+    Object.keys(localData.buckets || {}).map((name) => name.toLowerCase())
+  );
+
+  const groupKeyOf = (item: IncomingItem): string | null => {
+    if (item.kind === "fixed" && item.fixed && !localFixedIds.has(item.fixed.id))
+      return `fixed:${item.fixed.id}`;
+    if (
+      item.kind === "bucket" &&
+      item.bucket &&
+      !localBucketNames.has(item.bucket.name.toLowerCase())
+    )
+      return `bucket:${item.bucket.name.toLowerCase()}`;
+    return null; // not groupable — stays an individual item
+  };
+
+  const groups = new Map<string, IncomingItem[]>();
+  incoming.forEach((item) => {
+    const groupKey = groupKeyOf(item);
+    if (!groupKey) return;
+    groups.set(groupKey, [...(groups.get(groupKey) || []), item]);
+  });
+
+  const result: IncomingItem[] = [];
+  const emitted = new Set<string>();
+  incoming.forEach((item) => {
+    const groupKey = groupKeyOf(item);
+    if (!groupKey) {
+      result.push(item);
+      return;
+    }
+    if (emitted.has(groupKey)) return;
+    emitted.add(groupKey);
+    const members = groups.get(groupKey)!;
+    if (members.length === 1) {
+      result.push(members[0]);
+      return;
+    }
+    const byFrom = [...members].sort((first, second) => {
+      const fromOf = (candidate: IncomingItem) =>
+        candidate.kind === "fixed"
+          ? candidate.fixed!.state.from
+          : candidate.bucket!.state.from;
+      return fromOf(first) < fromOf(second) ? -1 : 1;
+    });
+    // The resolved current state (latest `from`) fronts the card.
+    result.push({ ...byFrom[byFrom.length - 1], grouped: byFrom });
+  });
+  return result;
+};
+
 // The diff, on download (RFC §4.2). Additive-only: a remote backup lacking
 // a local item never deletes anything locally.
 export const diffSnapshots = ({
@@ -134,7 +203,34 @@ export const diffSnapshots = ({
     if ((rejections[item.key] || []).indexOf(item.hash) !== -1) return; // EC-4
     incoming.push({ ...item, isChange: local.has(item.key) });
   });
-  return incoming;
+  return groupNewDefinitions(incoming, localData);
+};
+
+// Categories are not reviewable items — they travel alongside entries and
+// buckets (AC-3.10) as an additive, case-insensitive union (local casing
+// and order win). Names promoted to buckets are excluded, matching how
+// creating a bucket removes the standalone category locally.
+export const mergeCategories = ({
+  localCategories,
+  remoteCategories,
+  buckets,
+}: {
+  localCategories: string[];
+  remoteCategories: string[];
+  buckets: { [name: string]: any };
+}): string[] => {
+  const bucketNames = new Set(
+    Object.keys(buckets || {}).map((name) => name.toLowerCase())
+  );
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  [...(localCategories || []), ...(remoteCategories || [])].forEach((name) => {
+    const lower = String(name).toLowerCase();
+    if (bucketNames.has(lower) || seen.has(lower)) return;
+    seen.add(lower);
+    merged.push(name);
+  });
+  return merged;
 };
 
 // Two snapshots hold the same content when their syncable units match
@@ -151,9 +247,14 @@ export const snapshotsContentEqual = (
     if (mapB.get(key) !== hash) equal = false;
   });
   if (!equal) return false;
-  const categoriesA = [...(a.categories || [])].sort();
-  const categoriesB = [...(b.categories || [])].sort();
-  return canonicalStringify(categoriesA) === canonicalStringify(categoriesB);
+  // Case-insensitive, like every other category comparison in the app —
+  // otherwise two members with different casings would re-upload forever.
+  const normalize = (categories?: string[]) =>
+    (categories || []).map((name) => name.toLowerCase()).sort();
+  return (
+    canonicalStringify(normalize(a.categories)) ===
+    canonicalStringify(normalize(b.categories))
+  );
 };
 
 const byFromAscending = (first: any, second: any) =>

--- a/src/integrationTests/helpers/renderApp.tsx
+++ b/src/integrationTests/helpers/renderApp.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, act, RenderResult } from "@testing-library/react";
 import userEvent, { UserEvent } from "@testing-library/user-event";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useHistory } from "react-router-dom";
 import { setupStore } from "../../redux/store";
 import WithBalance from "../../components/WithBalance";
 import WithDataDisclaimer from "../../components/Dashboard/WithDataDisclaimer";
@@ -12,6 +12,11 @@ import { setSession, SyncSession } from "../../services/session";
 interface RenderAppResult extends RenderResult {
   store: ReturnType<typeof setupStore>;
   user: UserEvent;
+  /**
+   * Programmatic navigation for routes with no in-app link (the browser
+   * address-bar analogue). Prefer clicking real links where they exist.
+   */
+  navigate: (route: string) => Promise<void>;
 }
 
 interface RenderAppOptions {
@@ -33,11 +38,22 @@ export async function renderApp(
   const store = setupStore();
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
+  // Captures the router's history so tests can navigate to routes that
+  // have no in-app link (renders nothing).
+  const historyRef: { current: ReturnType<typeof useHistory> | null } = {
+    current: null,
+  };
+  const HistoryCapture = () => {
+    historyRef.current = useHistory();
+    return null;
+  };
+
   let result!: RenderResult;
   await act(async () => {
     result = render(
       <Provider store={store}>
         <MemoryRouter initialEntries={[initialRoute]}>
+          <HistoryCapture />
           <WithBalance>
             <WithDataDisclaimer>
               {/** @ts-ignore */}
@@ -49,5 +65,11 @@ export async function renderApp(
     );
   });
 
-  return { ...result, store, user };
+  const navigate = async (route: string) => {
+    await act(async () => {
+      historyRef.current!.push(route);
+    });
+  };
+
+  return { ...result, store, user, navigate };
 }

--- a/src/integrationTests/qaFixes.test.tsx
+++ b/src/integrationTests/qaFixes.test.tsx
@@ -1,0 +1,338 @@
+import { screen, cleanup } from "@testing-library/react";
+import { renderApp } from "./helpers/renderApp";
+import {
+  installFakeSyncServer,
+  FakeSyncServer,
+} from "./helpers/fakeSyncServer";
+import { seedEntries, ts, MAY } from "./helpers/seed";
+
+/**
+ * QA round-1 fixes (multi-user sync PR 7):
+ * - D1 (MAJOR): user-created categories travel through sync — the
+ *   receiving member gets them, the party backup retains them, and both
+ *   members converge to "You're up to date." (AC-3.10).
+ * - D2: a brand-new fixed entry with several history states is ONE card
+ *   whose decision applies to all states (RFC §4.1).
+ * - D3: navigating away mid-review clears the staged review — a later
+ *   direct visit to /sync-review finds nothing to review.
+ * - D4: action aria-labels keep the contributor's name casing.
+ */
+
+const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
+
+let server: FakeSyncServer;
+let confirmSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.useFakeTimers();
+  jest.setSystemTime(PINNED_DATE);
+  server = installFakeSyncServer();
+  confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+});
+
+afterEach(() => {
+  confirmSpy.mockRestore();
+  server.restore();
+  jest.useRealTimers();
+});
+
+const jane = {
+  email: "jane@example.com",
+  password: "hunter22!",
+  firstName: "Jane",
+  lastName: "Doe",
+};
+const tom = {
+  email: "tom@example.com",
+  password: "hunter33!",
+  firstName: "Tom",
+  lastName: "Doe",
+};
+
+const janeGroceries = {
+  date: ts(2026, MAY),
+  amount: "75",
+  description: "Groceries",
+  type: "expense" as const,
+  categories_path: ",groceries,",
+};
+
+const tomPetEntry = {
+  id: "tom-entry",
+  date: ts(2026, MAY, 10),
+  amount: "30",
+  description: "Vet visit",
+  type: "expense",
+  categories_path: ",pet care,",
+  addedBy: { id: "user-2", name: "Tom" },
+};
+
+const envelope = (data: Partial<any>) => ({
+  app: "react-expenses-manager",
+  schemaVersion: 1,
+  exportedAt: "2026-05-14T12:00:00.000Z",
+  data: {
+    balance: [],
+    buckets: {},
+    categories: [],
+    fixedEntries: [],
+    ...data,
+  },
+});
+
+const clickSync = async (user: any) => {
+  await user.click(
+    await screen.findByRole("button", { name: "Sync with party" })
+  );
+};
+
+const acceptAllAndFinish = async (user: any) => {
+  await user.click(screen.getByRole("button", { name: "Accept all" }));
+  await user.click(
+    await screen.findByRole("button", { name: "Upload & finish" })
+  );
+  await user.click(await screen.findByRole("button", { name: "Done" }));
+};
+
+describe("D1 — categories travel through sync (AC-3.10)", () => {
+  it("a user-created category reaches the other member, survives every upload, and both converge", async () => {
+    // Tom's backup carries his custom "Pet Care" category + an entry
+    // using it. Jane has her own data and no such category.
+    const [janeSeeded] = seedEntries([janeGroceries]);
+    server.seedUser(jane);
+    server.seedUser(tom);
+    server.seedPartyWithMembers([jane.email, tom.email]);
+    server.seedRemoteBackup(
+      envelope({
+        balance: [tomPetEntry],
+        categories: ["Pet Care"],
+      }) as any
+    );
+    const session = server.loginAs(jane.email);
+    const { user } = await renderApp("/data-management", { session });
+
+    // Jane reviews and accepts Tom's entry.
+    await clickSync(user);
+    expect(await screen.findByText("Item 1 of 1")).toBeInTheDocument();
+    await acceptAllAndFinish(user);
+
+    // The uploaded party backup RETAINS the category (it used to be
+    // silently dropped) and now also carries Jane's entry.
+    const uploads = server.getUploadedBackups();
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0].envelope.data.categories).toEqual(["Pet Care"]);
+
+    // Jane sees the category on the Categories screen…
+    await user.click(screen.getByRole("link", { name: "Categories" }));
+    expect(await screen.findByText("Pet Care")).toBeInTheDocument();
+
+    // …and in the entry form's category selector.
+    await user.click(screen.getByRole("link", { name: "Home" }));
+    await user.click(await screen.findByRole("link", { name: /add expenses/i }));
+    const selector = await screen.findByRole("combobox");
+    expect(selector).toContainHTML("Pet Care");
+
+    // Jane's follow-up sync converges: nothing new, no ping-pong upload.
+    await user.click(screen.getByRole("link", { name: "Data Management" }));
+    await clickSync(user);
+    expect(await screen.findByText("You're up to date.")).toBeInTheDocument();
+    expect(server.getUploadedBackups()).toHaveLength(1);
+
+    // Now the other member: Tom's device has his own data + category.
+    cleanup();
+    localStorage.clear();
+    localStorage.setItem("everShowDataDisclaimer", "0");
+    seedEntries([
+      {
+        date: ts(2026, MAY, 10),
+        amount: "30",
+        description: "Vet visit",
+        type: "expense",
+        categories_path: ",pet care,",
+      },
+    ]);
+    // Tom's own entry has a different local id than the backup's — align
+    // by seeding the exact backup entry instead.
+    localStorage.setItem("balance", JSON.stringify([tomPetEntry]));
+    localStorage.setItem("categories", JSON.stringify(["Pet Care"]));
+    const tomSession = server.loginAs(tom.email);
+    const { user: tomUser } = await renderApp("/data-management", {
+      session: tomSession,
+    });
+
+    // Tom syncs: Jane's entry comes in; accept → upload retains the
+    // category; the follow-up sync is clean.
+    await clickSync(tomUser);
+    expect(await screen.findByText("Item 1 of 1")).toBeInTheDocument();
+    await acceptAllAndFinish(tomUser);
+    const allUploads = server.getUploadedBackups();
+    expect(
+      allUploads[allUploads.length - 1].envelope.data.categories
+    ).toEqual(["Pet Care"]);
+    expect(
+      allUploads[allUploads.length - 1].envelope.data.balance
+    ).toHaveLength(2);
+
+    await clickSync(tomUser);
+    expect(await screen.findByText("You're up to date.")).toBeInTheDocument();
+    expect(server.getUploadedBackups()).toHaveLength(allUploads.length);
+    // Jane's seeded entry id round-tripped intact.
+    expect(
+      allUploads[allUploads.length - 1].envelope.data.balance.some(
+        (entry: any) => entry.id === janeSeeded.id
+      )
+    ).toBe(true);
+  });
+
+  it("a category promoted to a bucket is not resurrected by the union", async () => {
+    seedEntries([janeGroceries]);
+    // Jane already promoted "Pet Care" to a bucket locally.
+    localStorage.setItem(
+      "buckets",
+      JSON.stringify({ "Pet Care": [{ from: "0000-00", limit: 50 }] })
+    );
+    server.seedUser(jane);
+    server.seedPartyWithMembers([jane.email]);
+    // The remote backup still lists it as a plain category.
+    server.seedRemoteBackup(
+      envelope({
+        balance: [],
+        categories: ["pet care"],
+      }) as any
+    );
+    const session = server.loginAs(jane.email);
+    const { user } = await renderApp("/data-management", { session });
+
+    await clickSync(user);
+    // Local-only additions path (bucket + entry are local-only).
+    expect(await screen.findByText("You're up to date.")).toBeInTheDocument();
+    const uploads = server.getUploadedBackups();
+    expect(uploads).toHaveLength(1);
+    // The bucket name is excluded from the categories union.
+    expect(uploads[0].envelope.data.categories).toEqual([]);
+    expect(Object.keys(uploads[0].envelope.data.buckets)).toEqual(["Pet Care"]);
+  });
+});
+
+describe("D2 — one card per brand-new definition (RFC §4.1)", () => {
+  it("a multi-state new fixed entry reviews as one card and one accept applies every state", async () => {
+    seedEntries([janeGroceries]);
+    server.seedUser(jane);
+    server.seedPartyWithMembers([jane.email]);
+    server.seedRemoteBackup(
+      envelope({
+        balance: [],
+        fixedEntries: [
+          {
+            id: "tom-fixed",
+            type: "expense",
+            history: [
+              {
+                from: "2026-01",
+                amount: "9.99",
+                description: "Streaming",
+                categories_path: ",eating out,",
+                addedBy: { id: "user-2", name: "Tom" },
+              },
+              {
+                from: "2026-04",
+                amount: "12.99",
+                description: "Streaming 4K",
+                categories_path: ",eating out,",
+                addedBy: { id: "user-2", name: "Tom" },
+              },
+            ],
+          },
+        ],
+      }) as any
+    );
+    const session = server.loginAs(jane.email);
+    const { user } = await renderApp("/data-management", { session });
+
+    await clickSync(user);
+
+    // ONE card — fronted by the resolved current state.
+    expect(await screen.findByText("Item 1 of 1")).toBeInTheDocument();
+    expect(screen.getByText("Streaming 4K")).toBeInTheDocument();
+    expect(screen.getByText("From 2026-04")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^Accept \$12\.99/ }));
+    await user.click(
+      await screen.findByRole("button", { name: "Upload & finish" })
+    );
+    await user.click(await screen.findByRole("button", { name: "Done" }));
+
+    // Every pending state went up with the accept.
+    const uploads = server.getUploadedBackups();
+    const uploadedFixed = uploads[0].envelope.data.fixedEntries.find(
+      (definition: any) => definition.id === "tom-fixed"
+    );
+    expect(uploadedFixed.history).toHaveLength(2);
+
+    // And the earlier state is live locally: January shows $9.99.
+    const nextSync = await screen.findByRole("button", {
+      name: "Sync with party",
+    });
+    expect(nextSync).toBeEnabled();
+  });
+});
+
+describe("D3 — navigating away clears the staged review (DESIGN §4.3)", () => {
+  it("a later direct visit to /sync-review finds nothing to review", async () => {
+    seedEntries([janeGroceries]);
+    server.seedUser(jane);
+    server.seedPartyWithMembers([jane.email]);
+    server.seedRemoteBackup(envelope({ balance: [tomPetEntry] }) as any);
+    const session = server.loginAs(jane.email);
+    const { user, navigate } = await renderApp("/data-management", {
+      session,
+    });
+
+    await clickSync(user);
+    expect(await screen.findByText("Item 1 of 1")).toBeInTheDocument();
+
+    // Walk away mid-review via the tab bar (silent, safe abandonment)…
+    await user.click(screen.getByRole("link", { name: "Home" }));
+    expect(
+      await screen.findByRole("link", { name: /add income/i })
+    ).toBeInTheDocument();
+
+    // …then come back to /sync-review directly (address-bar analogue).
+    await navigate("/sync-review");
+    expect(
+      await screen.findByText(/There's nothing to review right now/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Item 1 of/)).not.toBeInTheDocument();
+    expect(server.getUploadedBackups()).toEqual([]);
+  });
+});
+
+describe("D4 — aria-labels keep the contributor's name casing", () => {
+  it("action buttons read 'added by Tom', not 'added by tom'", async () => {
+    seedEntries([janeGroceries]);
+    server.seedUser(jane);
+    server.seedPartyWithMembers([jane.email]);
+    server.seedRemoteBackup(envelope({ balance: [tomPetEntry] }) as any);
+    const session = server.loginAs(jane.email);
+    const { user } = await renderApp("/data-management", { session });
+
+    await clickSync(user);
+    await screen.findByText("Item 1 of 1");
+
+    expect(
+      screen.getByRole("button", {
+        name: "Accept $30.00 expense added by Tom",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Modify $30.00 expense added by Tom",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Reject $30.00 expense added by Tom",
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/redux/syncManager/reducer.ts
+++ b/src/redux/syncManager/reducer.ts
@@ -17,6 +17,9 @@ import {
 export interface PendingReview {
   items: IncomingItem[];
   baseVersion: string;
+  // Categories travel alongside (AC-3.10): the remote list from the same
+  // download, merged as an additive union at commit time.
+  remoteCategories: string[];
 }
 
 // One-shot notice carried back to the Data Management card after a

--- a/src/redux/syncManager/syncThunk.ts
+++ b/src/redux/syncManager/syncThunk.ts
@@ -15,6 +15,7 @@ import { getSyncState, setSyncState } from "../../services/syncState";
 import {
   applyItems,
   diffSnapshots,
+  mergeCategories,
   snapshotsContentEqual,
   IncomingItem,
   Rejections,
@@ -60,6 +61,25 @@ const commitSyncState = (
 
 const isVersionConflict = (error: unknown) =>
   isSyncApiError(error) && error.code === SYNC_ERROR_CODES.VERSION_CONFLICT;
+
+// Writes a merged snapshot to localStorage and refreshes the live Redux
+// tree from it, exactly like a completed restore does.
+const commitMergedLocally = async (dispatch: Dispatch, merged: BackupData) => {
+  await storage.importData(merged);
+  const entries = getGroupedFilledEntriesByDate()(
+    merged.balance,
+    merged.fixedEntries
+  );
+  dispatch({
+    type: RESTORE_BACKUP,
+    payload: {
+      entries,
+      buckets: merged.buckets,
+      unbudgetedCategories: merged.categories,
+      fixedEntries: merged.fixedEntries,
+    },
+  });
+};
 
 export const syncWithParty =
   () =>
@@ -126,12 +146,34 @@ export const syncWithParty =
           return { type: "up-to-date" }; // AC-3.3 — no upload
         }
         // Local-only additions: silent upload of the local snapshot.
+        // Categories are carried as an additive union (AC-3.10) so a
+        // member's custom category is never dropped from the backup —
+        // note: this deviates from RFC §4.3's literal "PUT merged local
+        // snapshot" wording by unioning the category lists.
+        const merged: BackupData = {
+          ...localData,
+          categories: mergeCategories({
+            localCategories: localData.categories,
+            remoteCategories: remoteData.categories,
+            buckets: localData.buckets,
+          }),
+        };
         try {
           const { version } = await syncApi.putBackup({
             token,
             baseVersion: downloaded.version,
-            envelope: buildBackupEnvelope(localData) as BackupEnvelope,
+            envelope: buildBackupEnvelope(merged) as BackupEnvelope,
           });
+          // Adopt any newly received categories locally (commit happens
+          // only here, after the upload's 200).
+          if (
+            merged.categories.length !== localData.categories.length ||
+            merged.categories.some(
+              (name, index) => name !== localData.categories[index]
+            )
+          ) {
+            await commitMergedLocally(dispatch, merged);
+          }
           commitSyncState(party.id, version, syncState.rejections);
           return { type: "up-to-date" };
         } catch (uploadError) {
@@ -149,6 +191,7 @@ export const syncWithParty =
           pendingReview: {
             items: incoming as IncomingItem[],
             baseVersion: downloaded.version,
+            remoteCategories: remoteData.categories,
           },
         },
       });
@@ -184,6 +227,16 @@ export const completeReview =
     // survive; the accepted items still apply cleanly by itemKey.
     const localData: BackupData = await storage.exportData();
     const merged = applyItems(localData, acceptedItems);
+    // Categories travel alongside (AC-3.10): additive union with the
+    // remote list from the same download, excluding names the merged
+    // snapshot now holds as buckets.
+    const remoteCategories: string[] =
+      getState().syncManager.pendingReview?.remoteCategories || [];
+    merged.categories = mergeCategories({
+      localCategories: merged.categories,
+      remoteCategories,
+      buckets: merged.buckets,
+    });
 
     const { version } = await syncApi.putBackup({
       token: session.token,
@@ -192,7 +245,7 @@ export const completeReview =
     });
 
     // Commit — the only write to app localStorage in the whole flow.
-    await storage.importData(merged);
+    await commitMergedLocally(dispatch, merged);
     const syncState = getSyncState(party.id);
     const rejections: Rejections = { ...syncState.rejections };
     rejectedItems.forEach(({ key, hash }) => {
@@ -200,22 +253,6 @@ export const completeReview =
       if (existing.indexOf(hash) === -1) rejections[key] = [...existing, hash];
     });
     commitSyncState(party.id, version, rejections);
-
-    // Refresh the live Redux tree from the merged snapshot, exactly like
-    // a completed restore does.
-    const entries = getGroupedFilledEntriesByDate()(
-      merged.balance,
-      merged.fixedEntries
-    );
-    dispatch({
-      type: RESTORE_BACKUP,
-      payload: {
-        entries,
-        buckets: merged.buckets,
-        unbudgetedCategories: merged.categories,
-        fixedEntries: merged.fixedEntries,
-      },
-    });
     dispatch({
       type: SYNC_PENDING_REVIEW_SET,
       payload: { pendingReview: null },


### PR DESCRIPTION
Fixes the four defects from QA's round-1 verification of the multi-user sync feature (see `docs/multi-user-sync/TEST-PLAN.md`).

## Fixes
- **D1 (MAJOR)** — user-created categories now travel through sync (AC-3.10): `mergeCategories()` performs an additive, case-insensitive union of local + remote categories (excluding names promoted to buckets) in **both** upload paths (silent upload and wizard commit), and the union is what's written locally on commit so the Categories screen / entry-form selector pick it up. `snapshotsContentEqual` is case-insensitive for categories, so converged members reach "You're up to date" instead of ping-ponging uploads forever.
- **D2** — the wizard now shows **one card per brand-new fixed-entry/bucket definition** (resolved current state) instead of one card per history state (RFC §4.1); the decision applies to all pending states, with per-state rejection-memory entries.
- **D3** — navigating away mid-review clears the pending review (DESIGN §4.3 "navigating away ≡ Cancel"); returning to `/sync-review` directly shows the "nothing to review" screen.
- **D4** — wizard action aria-labels preserve the contributor's name casing ("…added by Tom").
- SyncCard state-update race fixed at the cause (act() warning source).

## Tests
- `qaFixes.test.tsx` (5 integration tests) including QA's required scenario: a user-created category with an entry travels through sync, appears on the receiving member's Categories screen and entry-form selector after accepting, and the party backup retains it across both members' subsequent syncs ending in "You're up to date."
- 6 new merge-engine unit tests (category union semantics, convergence, D2 grouping, per-state group rejections).

## Verification
Full jest: 226 passed, 14 pre-existing skips, 0 failures; server: 35/35; typecheck clean; lint clean on all 12 touched files. Version 1.6.2 + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XK2sxKjRfUxBMqyQHypqLB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XK2sxKjRfUxBMqyQHypqLB)_