### PR TITLE
Sync convergence: preserve remote items on upload (PR 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.3] - 2026-07-13
+
+### Fixed
+- Multi-user sync QA round 2 (D5): rejecting another member's item no
+  longer deletes it from the shared party backup or triggers an endless
+  upload ping-pong (AC-3.9, EC-2, AC-3.3/3.8). Both upload paths — the
+  silent local-only upload and the reviewed merge — now build the uploaded
+  snapshot as the union of the downloaded remote snapshot and the local
+  data (plus accepted/modified items), via a new `mergeSnapshotForUpload`
+  helper keyed by the merge engine's itemKeys. A remote item absent
+  locally (one this member rejected, now or in a prior sync) is retained
+  in the backup at its remote value, mirroring what `mergeCategories`
+  already did for categories; accepted-and-modified items still win over
+  the remote value (EC-5). The rejected item is never merged into the
+  rejecting member's own data, and the silent path now uploads only when
+  the union would actually change the backup, so a rejecting member
+  converges to "You're up to date." instead of re-uploading forever.
+  Consistent with the additive-only design, sync still carries no
+  deletions in either direction.
+
 ## [1.6.2] - 2026-07-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the union would actually change the backup, so a rejecting member
   converges to "You're up to date." instead of re-uploading forever.
   Consistent with the additive-only design, sync still carries no
-  deletions in either direction.
+  deletions in either direction. Local category adoption (AC-3.10) is
+  decoupled from the upload-skip gate: a member otherwise fully in sync who
+  receives a new standalone remote-only category adopts it locally even
+  when no upload is needed, then stays converged with no re-upload loop.
 
 ## [1.6.2] - 2026-07-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/src/helpers/syncMergeHelper/syncMergeHelper.test.ts
+++ b/src/helpers/syncMergeHelper/syncMergeHelper.test.ts
@@ -5,6 +5,7 @@ import {
   diffSnapshots,
   extractItems,
   mergeCategories,
+  mergeSnapshotForUpload,
   snapshotsContentEqual,
 } from "./syncMergeHelper";
 import { BackupData } from "../../services/syncApi/contract";
@@ -392,5 +393,115 @@ describe("category merging (AC-3.10 — QA D1)", () => {
     expect(
       snapshotsContentEqual(a, { ...emptyData(), categories: [] })
     ).toBe(false);
+  });
+});
+
+describe("mergeSnapshotForUpload (D5 — union preserves remote items)", () => {
+  it("retains a remote-only item (rejected / rejected-in-a-prior-sync) at its remote value", () => {
+    // `base` is the local snapshot with accepted items applied — it lacks
+    // the remote item X (this member rejected it, so it never merged
+    // locally). The upload must still carry X so the party backup keeps it.
+    const base = { ...emptyData(), balance: [entry("local-only")] };
+    const remoteData = {
+      ...emptyData(),
+      balance: [entry("local-only"), entry("X", { amount: "99" })],
+    };
+    const merged = mergeSnapshotForUpload({ base, remoteData });
+    const ids = merged.balance.map((item: any) => item.id).sort();
+    expect(ids).toEqual(["X", "local-only"]);
+    // Remote value preserved verbatim.
+    expect(merged.balance.find((item: any) => item.id === "X").amount).toEqual(
+      "99"
+    );
+  });
+
+  it("retains a local-only item (additive, remote lacks it)", () => {
+    const base = {
+      ...emptyData(),
+      balance: [entry("shared"), entry("mine")],
+    };
+    const remoteData = { ...emptyData(), balance: [entry("shared")] };
+    const merged = mergeSnapshotForUpload({ base, remoteData });
+    expect(merged.balance.map((item: any) => item.id).sort()).toEqual([
+      "mine",
+      "shared",
+    ]);
+  });
+
+  it("a modified-accepted item wins over the remote value (EC-5)", () => {
+    // Same itemKey (entry:e1) in base and remote, different content: base
+    // holds the member's MODIFIED value, which must win in the upload.
+    const base = { ...emptyData(), balance: [entry("e1", { amount: "5" })] };
+    const remoteData = {
+      ...emptyData(),
+      balance: [entry("e1", { amount: "99" })],
+    };
+    const merged = mergeSnapshotForUpload({ base, remoteData });
+    expect(merged.balance).toHaveLength(1);
+    expect(merged.balance[0].amount).toEqual("5");
+  });
+
+  it("unions remote-only fixed-entry states and bucket states by itemKey", () => {
+    const base = {
+      ...emptyData(),
+      fixedEntries: [
+        {
+          id: "f1",
+          type: "expense",
+          history: [{ from: "2026-01", amount: "9", categories_path: ",fun," }],
+        },
+      ],
+      buckets: { Groceries: [{ from: "2026-01", limit: 100 }] },
+    };
+    const remoteData = {
+      ...emptyData(),
+      fixedEntries: [
+        {
+          id: "f1",
+          type: "expense",
+          history: [
+            { from: "2026-01", amount: "9", categories_path: ",fun," },
+            { from: "2026-03", amount: "12", categories_path: ",fun," },
+          ],
+        },
+      ],
+      buckets: {
+        Groceries: [
+          { from: "2026-01", limit: 100 },
+          { from: "2026-03", limit: 150 },
+        ],
+      },
+    };
+    const merged = mergeSnapshotForUpload({ base, remoteData });
+    // The remote-only later states are retained; existing states unchanged.
+    expect(merged.fixedEntries[0].history.map((s: any) => s.from)).toEqual([
+      "2026-01",
+      "2026-03",
+    ]);
+    expect(merged.buckets.Groceries.map((s: any) => s.from)).toEqual([
+      "2026-01",
+      "2026-03",
+    ]);
+  });
+
+  it("does not mutate its inputs", () => {
+    const base = { ...emptyData(), balance: [entry("a")] };
+    const remoteData = { ...emptyData(), balance: [entry("a"), entry("b")] };
+    mergeSnapshotForUpload({ base, remoteData });
+    expect(base.balance).toHaveLength(1);
+    expect(remoteData.balance).toHaveLength(2);
+  });
+
+  it("converges: after uploading the union, the backup content-equals the upload (no further upload)", () => {
+    // Member A rejected X: local (base) lacks X, remote has X. The upload
+    // union == remote content, so snapshotsContentEqual(upload, remote) is
+    // true — the next sync makes NO upload, and A never re-prompts for X.
+    const base = { ...emptyData(), balance: [entry("shared")] };
+    const remoteData = {
+      ...emptyData(),
+      balance: [entry("shared"), entry("X")],
+    };
+    const uploadSnapshot = mergeSnapshotForUpload({ base, remoteData });
+    expect(snapshotsContentEqual(uploadSnapshot, remoteData)).toBe(true);
   });
 });

--- a/src/helpers/syncMergeHelper/syncMergeHelper.ts
+++ b/src/helpers/syncMergeHelper/syncMergeHelper.ts
@@ -328,3 +328,41 @@ export const applyItems = (
 
   return data;
 };
+
+// The union of `base` and `remoteData`, keyed by itemKey — the snapshot a
+// sync UPLOADS (RFC §4.3 step 6). `base` is the local snapshot with the
+// review's accepted/modified items already applied (applyItems), so its
+// items win: any remote item whose itemKey is ALSO in `base` keeps the
+// base value (so a modified-accepted item uploads with the modified value,
+// EC-5, and a local item wins over a stale remote one). Only remote items
+// ABSENT from `base` are added, at their remote value.
+//
+// This is the entry/fixed/bucket analogue of mergeCategories' additive
+// union (AC-3.10). It fixes D5: uploads used to be built from LOCAL data
+// alone, so a remote item not present locally — one this member rejected,
+// now or in a prior sync — was wholesale-dropped from the party backup,
+// violating AC-3.9 and looping uploads forever. Retaining it here keeps
+// the backup stable and lets both members converge.
+//
+// Consistent with the additive-only design (RFC §4.2): just as a download
+// never deletes a local item, an upload never deletes a remote one — sync
+// carries no deletions in either direction. A locally-removed item that is
+// still remote is therefore RETAINED in the upload (not resurrected
+// locally — the local commit uses `base`, never this union), matching how
+// the download side already re-offers such an item rather than dropping it.
+export const mergeSnapshotForUpload = ({
+  base,
+  remoteData,
+}: {
+  base: BackupData;
+  remoteData: BackupData;
+}): BackupData => {
+  const present = new Set<string>();
+  extractItems(base).forEach((item) => present.add(item.key));
+  const remoteOnly = extractItems(remoteData).filter(
+    (item) => !present.has(item.key)
+  );
+  // Categories are unioned separately (mergeCategories) by the callers;
+  // applyItems preserves base.categories untouched.
+  return applyItems(base, remoteOnly);
+};

--- a/src/integrationTests/syncConvergence.test.tsx
+++ b/src/integrationTests/syncConvergence.test.tsx
@@ -184,3 +184,57 @@ describe("D5 — rejecting a member's item keeps it in the backup and converges"
     expect(server.getUploadedBackups()).toHaveLength(2);
   });
 });
+
+// The upload-skip gate (D5) must NOT swallow standalone-category adoption:
+// a member otherwise fully in sync who receives a new remote-only category
+// (added by another member via AddCategory, no entry) must ADOPT it locally
+// even though no upload is needed (AC-3.10) — and then stay converged.
+describe("AC-3.10 — adopting a standalone remote-only category needs no upload", () => {
+  // The exact same entry lives on B's device and in the backup, so nothing
+  // is incoming and no item needs uploading — only the category differs.
+  const sharedEntry = {
+    id: "shared-1",
+    date: ts(2026, MAY, 5),
+    amount: "40",
+    description: "Dinner",
+    type: "expense",
+    categories_path: ",eating out,",
+  };
+
+  it("B adopts 'Travel' locally, reaches up-to-date with NO upload, and does not re-upload on re-sync", async () => {
+    server.seedUser(jane);
+    server.seedPartyWithMembers([jane.email]);
+    // The backup carries B's entry plus a standalone category another member
+    // created (no entry uses it).
+    server.seedRemoteBackup(
+      envelope({ balance: [sharedEntry], categories: ["Travel"] }) as any
+    );
+    // B's device has the entry but not the category.
+    localStorage.setItem("everShowDataDisclaimer", "0");
+    localStorage.setItem("balance", JSON.stringify([sharedEntry]));
+    const session = server.loginAs(jane.email);
+    const { user } = await renderApp("/data-management", { session });
+
+    // Sync: nothing to review, no upload needed — but "Travel" is adopted.
+    await clickSync(user);
+    expect(await screen.findByText("You're up to date.")).toBeInTheDocument();
+    expect(server.getUploadedBackups()).toEqual([]);
+
+    // The category is now on B's Categories screen…
+    await user.click(screen.getByRole("link", { name: "Categories" }));
+    expect(await screen.findByText("Travel")).toBeInTheDocument();
+
+    // …and in the entry form's category selector.
+    await user.click(screen.getByRole("link", { name: "Home" }));
+    await user.click(
+      await screen.findByRole("link", { name: /add expenses/i })
+    );
+    expect(await screen.findByRole("combobox")).toContainHTML("Travel");
+
+    // A re-sync stays converged with NO upload — B is not stuck re-uploading.
+    await user.click(screen.getByRole("link", { name: "Data Management" }));
+    await clickSync(user);
+    expect(await screen.findByText("You're up to date.")).toBeInTheDocument();
+    expect(server.getUploadedBackups()).toEqual([]);
+  });
+});

--- a/src/integrationTests/syncConvergence.test.tsx
+++ b/src/integrationTests/syncConvergence.test.tsx
@@ -1,0 +1,186 @@
+import { screen, cleanup } from "@testing-library/react";
+import { renderApp } from "./helpers/renderApp";
+import {
+  installFakeSyncServer,
+  FakeSyncServer,
+} from "./helpers/fakeSyncServer";
+import { seedEntries, ts, MAY } from "./helpers/seed";
+
+/**
+ * QA round-2 fix (multi-user sync PR 8) — D5 (MAJOR): rejecting another
+ * member's item must NOT delete it from the shared party backup, and must
+ * NOT trigger an unbounded upload ping-pong. Both upload paths union the
+ * downloaded remote snapshot into what they upload, so a rejected item —
+ * absent locally — is RETAINED in the backup (AC-3.9), and both members
+ * converge to "You're up to date." (AC-3.3/3.8, EC-2 no-silent-loss).
+ */
+
+const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
+
+let server: FakeSyncServer;
+let confirmSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.useFakeTimers();
+  jest.setSystemTime(PINNED_DATE);
+  server = installFakeSyncServer();
+  confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+});
+
+afterEach(() => {
+  confirmSpy.mockRestore();
+  server.restore();
+  jest.useRealTimers();
+});
+
+const jane = {
+  email: "jane@example.com",
+  password: "hunter22!",
+  firstName: "Jane",
+  lastName: "Doe",
+};
+const tom = {
+  email: "tom@example.com",
+  password: "hunter33!",
+  firstName: "Tom",
+  lastName: "Doe",
+};
+
+const janeGroceries = {
+  date: ts(2026, MAY),
+  amount: "75",
+  description: "Groceries",
+  type: "expense" as const,
+  categories_path: ",groceries,",
+};
+
+// Tom's item X — already in the party backup ("Tom added X and synced").
+const tomEntryX = {
+  id: "tom-entry",
+  date: ts(2026, MAY, 10),
+  amount: "30",
+  description: "Vet visit",
+  type: "expense",
+  categories_path: ",pet care,",
+  addedBy: { id: "user-2", name: "Tom" },
+};
+
+const envelope = (data: Partial<any>) => ({
+  app: "react-expenses-manager",
+  schemaVersion: 1,
+  exportedAt: "2026-05-14T12:00:00.000Z",
+  data: {
+    balance: [],
+    buckets: {},
+    categories: [],
+    fixedEntries: [],
+    ...data,
+  },
+});
+
+const clickSync = async (user: any) => {
+  await user.click(
+    await screen.findByRole("button", { name: "Sync with party" })
+  );
+};
+
+const hasEntry = (env: any, id: string) =>
+  env.data.balance.some((entry: any) => entry.id === id);
+
+describe("D5 — rejecting a member's item keeps it in the backup and converges", () => {
+  it("A rejects X: X stays in the party backup, A converges with no ping-pong and is never re-prompted", async () => {
+    const [janeSeeded] = seedEntries([janeGroceries]);
+    server.seedUser(jane);
+    server.seedUser(tom);
+    server.seedPartyWithMembers([jane.email, tom.email]);
+    // The party backup already holds Tom's entry X.
+    server.seedRemoteBackup(envelope({ balance: [tomEntryX] }) as any);
+    const session = server.loginAs(jane.email);
+    const { user } = await renderApp("/data-management", { session });
+
+    // Jane (A) syncs → X is incoming → she REJECTS it.
+    await clickSync(user);
+    expect(await screen.findByText("Item 1 of 1")).toBeInTheDocument();
+    await user.click(
+      await screen.findByRole("button", { name: /^Reject \$30\.00/ })
+    );
+    await user.click(
+      await screen.findByRole("button", { name: "Upload & finish" })
+    );
+    await user.click(await screen.findByRole("button", { name: "Done" }));
+
+    // AC-3.9: X was NOT dropped from the uploaded backup — it is retained
+    // alongside Jane's own entry.
+    expect(server.getUploadedBackups()).toHaveLength(1);
+    expect(hasEntry(server.getUploadedBackups()[0].envelope, "tom-entry")).toBe(
+      true
+    );
+    expect(
+      hasEntry(server.getUploadedBackups()[0].envelope, janeSeeded.id)
+    ).toBe(true);
+
+    // Jane's re-sync converges with NO further upload and NO re-prompt for
+    // X (rejection is permanent; the backup keeps X regardless).
+    await clickSync(user);
+    expect(await screen.findByText("You're up to date.")).toBeInTheDocument();
+    expect(screen.queryByText("Item 1 of 1")).not.toBeInTheDocument();
+    expect(server.getUploadedBackups()).toHaveLength(1);
+
+    // A third re-sync is still stable — no endless upload loop.
+    await clickSync(user);
+    expect(await screen.findByText("You're up to date.")).toBeInTheDocument();
+    expect(server.getUploadedBackups()).toHaveLength(1);
+  });
+
+  it("the other member B still receives the backup (X intact) and also converges", async () => {
+    seedEntries([janeGroceries]);
+    server.seedUser(jane);
+    server.seedUser(tom);
+    server.seedPartyWithMembers([jane.email, tom.email]);
+    server.seedRemoteBackup(envelope({ balance: [tomEntryX] }) as any);
+
+    // A rejects X first, leaving the backup = Jane's entry + X.
+    const session = server.loginAs(jane.email);
+    const { user } = await renderApp("/data-management", { session });
+    await clickSync(user);
+    expect(await screen.findByText("Item 1 of 1")).toBeInTheDocument();
+    await user.click(
+      await screen.findByRole("button", { name: /^Reject \$30\.00/ })
+    );
+    await user.click(
+      await screen.findByRole("button", { name: "Upload & finish" })
+    );
+    await user.click(await screen.findByRole("button", { name: "Done" }));
+    expect(server.getUploadedBackups()).toHaveLength(1);
+
+    // Now Tom (B), whose device still holds X, on a fresh device.
+    cleanup();
+    localStorage.clear();
+    localStorage.setItem("everShowDataDisclaimer", "0");
+    localStorage.setItem("balance", JSON.stringify([tomEntryX]));
+    const tomSession = server.loginAs(tom.email);
+    const { user: tomUser } = await renderApp("/data-management", {
+      session: tomSession,
+    });
+
+    // Jane's entry is incoming; Tom accepts it. His upload retains X.
+    await clickSync(tomUser);
+    expect(await screen.findByText("Item 1 of 1")).toBeInTheDocument();
+    await tomUser.click(screen.getByRole("button", { name: "Accept all" }));
+    await tomUser.click(
+      await screen.findByRole("button", { name: "Upload & finish" })
+    );
+    await tomUser.click(await screen.findByRole("button", { name: "Done" }));
+
+    expect(server.getUploadedBackups()).toHaveLength(2);
+    const tomUpload = server.getUploadedBackups()[1].envelope;
+    expect(hasEntry(tomUpload, "tom-entry")).toBe(true);
+    expect(tomUpload.data.balance).toHaveLength(2);
+
+    // Tom's re-sync is clean — no ping-pong.
+    await clickSync(tomUser);
+    expect(await screen.findByText("You're up to date.")).toBeInTheDocument();
+    expect(server.getUploadedBackups()).toHaveLength(2);
+  });
+});

--- a/src/redux/syncManager/reducer.ts
+++ b/src/redux/syncManager/reducer.ts
@@ -3,6 +3,7 @@
 import { getSession, SyncSession } from "../../services/session";
 import { Party } from "../../services/syncApi/contract";
 import { IncomingItem } from "../../helpers/syncMergeHelper/syncMergeHelper";
+import { BackupData } from "../../services/syncApi/contract";
 import {
   SYNC_CARD_NOTICE_SET,
   SYNC_PARTY_SET,
@@ -17,9 +18,13 @@ import {
 export interface PendingReview {
   items: IncomingItem[];
   baseVersion: string;
-  // Categories travel alongside (AC-3.10): the remote list from the same
-  // download, merged as an additive union at commit time.
-  remoteCategories: string[];
+  // The FULL remote snapshot from the same download (AC-3.10 + D5). Its
+  // categories merge as an additive union at commit time; its entries /
+  // fixed states / buckets are unioned into the uploaded snapshot so a
+  // rejected item — absent locally — stays in the party backup instead of
+  // being dropped (AC-3.9). The wizard binds to THIS download, never a
+  // re-fetch.
+  remoteData: BackupData;
 }
 
 // One-shot notice carried back to the Data Management card after a

--- a/src/redux/syncManager/syncThunk.ts
+++ b/src/redux/syncManager/syncThunk.ts
@@ -162,14 +162,34 @@ export const syncWithParty =
           base: withCategories,
           remoteData,
         });
-        // Upload only when it would actually change the backup. If the
-        // upload snapshot already content-equals the remote, this member's
-        // local data adds nothing new — the only differences are remote
-        // items this member rejected — so we're up to date with NO upload.
-        // This is what lets a rejecting member converge (AC-3.3/D5): their
+        // Adopting a remote-only category and deciding whether to upload are
+        // INDEPENDENT (AC-3.10 vs AC-3.9/D5). A member who is otherwise in
+        // sync but receives a new standalone category must adopt it locally
+        // even when no upload is needed — otherwise that category diverges
+        // permanently. So: adopt `withCategories` locally whenever the
+        // unioned category list differs from local (never the item union —
+        // rejected remote items must not merge into this device, AC-3.9)…
+        const categoriesChangedLocally =
+          withCategories.categories.length !== localData.categories.length ||
+          withCategories.categories.some(
+            (name, index) => name !== localData.categories[index]
+          );
+        // …and upload only when the union would actually CHANGE the backup.
+        // If the upload snapshot already content-equals the remote, local
+        // adds nothing new — the only differences are remote items this
+        // member rejected — so this member is up to date with NO upload.
+        // That is what lets a rejecting member converge (AC-3.3/D5): their
         // local permanently lacks the rejected item, yet they must stop
         // re-uploading. (Subsumes the old local≡remote no-upload case.)
         if (snapshotsContentEqual(uploadSnapshot, remoteData)) {
+          if (categoriesChangedLocally) {
+            // Committing without an upload is safe here: the remote already
+            // holds these categories (that is why the snapshots compare
+            // equal), so there is nothing to push — we only mirror them
+            // locally. No sync.state version write, matching the download-
+            // adopt-only paths.
+            await commitMergedLocally(dispatch, withCategories);
+          }
           return { type: "up-to-date" };
         }
         try {
@@ -182,12 +202,7 @@ export const syncWithParty =
           // only here, after the upload's 200). We commit `withCategories`,
           // NOT the upload union — rejected remote items must never merge
           // into this device's data (AC-3.9).
-          if (
-            withCategories.categories.length !== localData.categories.length ||
-            withCategories.categories.some(
-              (name, index) => name !== localData.categories[index]
-            )
-          ) {
+          if (categoriesChangedLocally) {
             await commitMergedLocally(dispatch, withCategories);
           }
           commitSyncState(party.id, version, syncState.rejections);

--- a/src/redux/syncManager/syncThunk.ts
+++ b/src/redux/syncManager/syncThunk.ts
@@ -16,6 +16,7 @@ import {
   applyItems,
   diffSnapshots,
   mergeCategories,
+  mergeSnapshotForUpload,
   snapshotsContentEqual,
   IncomingItem,
   Rejections,
@@ -142,15 +143,14 @@ export const syncWithParty =
 
       // Step 3 — nothing incoming.
       if (incoming.length === 0) {
-        if (snapshotsContentEqual(localData, remoteData)) {
-          return { type: "up-to-date" }; // AC-3.3 — no upload
-        }
-        // Local-only additions: silent upload of the local snapshot.
-        // Categories are carried as an additive union (AC-3.10) so a
-        // member's custom category is never dropped from the backup —
-        // note: this deviates from RFC §4.3's literal "PUT merged local
-        // snapshot" wording by unioning the category lists.
-        const merged: BackupData = {
+        // The snapshot this member would upload: local data + category
+        // union (AC-3.10) + every remote-only item retained (AC-3.9, D5).
+        // We adopt `withCategories` locally; the UPLOAD additionally unions
+        // in remote-only items (e.g. items this member rejected) so they
+        // stay in the party backup instead of being wholesale-dropped.
+        // Deviates from RFC §4.3's literal "PUT merged local snapshot"
+        // wording by unioning categories and remote items.
+        const withCategories: BackupData = {
           ...localData,
           categories: mergeCategories({
             localCategories: localData.categories,
@@ -158,21 +158,37 @@ export const syncWithParty =
             buckets: localData.buckets,
           }),
         };
+        const uploadSnapshot = mergeSnapshotForUpload({
+          base: withCategories,
+          remoteData,
+        });
+        // Upload only when it would actually change the backup. If the
+        // upload snapshot already content-equals the remote, this member's
+        // local data adds nothing new — the only differences are remote
+        // items this member rejected — so we're up to date with NO upload.
+        // This is what lets a rejecting member converge (AC-3.3/D5): their
+        // local permanently lacks the rejected item, yet they must stop
+        // re-uploading. (Subsumes the old local≡remote no-upload case.)
+        if (snapshotsContentEqual(uploadSnapshot, remoteData)) {
+          return { type: "up-to-date" };
+        }
         try {
           const { version } = await syncApi.putBackup({
             token,
             baseVersion: downloaded.version,
-            envelope: buildBackupEnvelope(merged) as BackupEnvelope,
+            envelope: buildBackupEnvelope(uploadSnapshot) as BackupEnvelope,
           });
           // Adopt any newly received categories locally (commit happens
-          // only here, after the upload's 200).
+          // only here, after the upload's 200). We commit `withCategories`,
+          // NOT the upload union — rejected remote items must never merge
+          // into this device's data (AC-3.9).
           if (
-            merged.categories.length !== localData.categories.length ||
-            merged.categories.some(
+            withCategories.categories.length !== localData.categories.length ||
+            withCategories.categories.some(
               (name, index) => name !== localData.categories[index]
             )
           ) {
-            await commitMergedLocally(dispatch, merged);
+            await commitMergedLocally(dispatch, withCategories);
           }
           commitSyncState(party.id, version, syncState.rejections);
           return { type: "up-to-date" };
@@ -191,7 +207,7 @@ export const syncWithParty =
           pendingReview: {
             items: incoming as IncomingItem[],
             baseVersion: downloaded.version,
-            remoteCategories: remoteData.categories,
+            remoteData,
           },
         },
       });
@@ -224,24 +240,41 @@ export const completeReview =
     if (!session || !party) throw new Error("Sync requires a party");
 
     // Local data is re-read at commit time so entries added mid-review
-    // survive; the accepted items still apply cleanly by itemKey.
+    // survive; the accepted items still apply cleanly by itemKey. `merged`
+    // is what we COMMIT locally: local data + accepted/modified items only,
+    // never rejected ones (AC-3.9).
     const localData: BackupData = await storage.exportData();
     const merged = applyItems(localData, acceptedItems);
-    // Categories travel alongside (AC-3.10): additive union with the
-    // remote list from the same download, excluding names the merged
-    // snapshot now holds as buckets.
-    const remoteCategories: string[] =
-      getState().syncManager.pendingReview?.remoteCategories || [];
+    // Categories + entries/fixed/buckets travel alongside from the SAME
+    // download (AC-3.10, D5). Categories: additive union excluding names
+    // the merged snapshot now holds as buckets.
+    const remoteData: BackupData =
+      getState().syncManager.pendingReview?.remoteData || {
+        balance: [],
+        buckets: {},
+        categories: [],
+        fixedEntries: [],
+      };
     merged.categories = mergeCategories({
       localCategories: merged.categories,
-      remoteCategories,
+      remoteCategories: remoteData.categories,
       buckets: merged.buckets,
+    });
+
+    // The UPLOAD additionally unions in every remote item absent from
+    // `merged` — a rejected item (or one rejected in a prior sync) — so it
+    // stays in the party backup rather than being wholesale-dropped
+    // (AC-3.9, D5). Accepted/modified items win because their itemKey is
+    // already in `merged` (EC-5). This union is NOT committed locally.
+    const uploadSnapshot = mergeSnapshotForUpload({
+      base: merged,
+      remoteData,
     });
 
     const { version } = await syncApi.putBackup({
       token: session.token,
       baseVersion,
-      envelope: buildBackupEnvelope(merged) as BackupEnvelope,
+      envelope: buildBackupEnvelope(uploadSnapshot) as BackupEnvelope,
     });
 
     // Commit — the only write to app localStorage in the whole flow.


### PR DESCRIPTION
Fixes defect D5 from QA's round-2 verification: rejecting another member's item deleted it from the shared party backup and caused an unbounded upload ping-pong.

## Problem
Downloads are additive (remote absence never deletes local), but both upload paths rebuilt the snapshot from **local data only** — so any remote item not present locally (a rejected item, or anything rejected in a prior sync) was dropped from the uploaded backup. This is the entry/fixed/bucket generalization of the category bug fixed in PR 7 for categories only. It violates AC-3.9 (a rejected item must remain in the party backup), EC-2 (no silent loss of a peer's data), and the convergence promise (AC-3.3/3.8).

## Fix
New pure helper `mergeSnapshotForUpload({ base, remoteData })`: the uploaded snapshot = local-with-accepted-changes (`base`) ∪ remote-only items at their remote value, keyed by the merge engine's existing itemKeys. Applied to **both** upload paths.
- **Modified-accepted** items win over remote (EC-5 preserved — the modified value is already in `base`).
- **Rejected** items are retained at their remote value (AC-3.9) but never written to the rejecting member's own localStorage.
- **Deletions**: retained on upload, consistent with the engine's documented additive-only design (sync carries no deletions in either direction). See the flagged behavior note below.
- The silent upload path is now gated on `!snapshotsContentEqual(uploadSnapshot, remoteData)`, so a rejecting member reaches a stable "You're up to date" with no further uploads — convergence.

## Tests
- 6 new merge-helper unit tests (remote-only retained, local-only retained, modified-wins, rejected-keeps-remote, converged content-equality).
- `syncConvergence.test.tsx` (2 integration tests): two members drive the reject-then-reconverge scenario — after A rejects X and both re-sync, X is still in the backup, both show "You're up to date", no endless uploads, A not re-prompted.

## Verification
Full jest: 234 passed, 14 pre-existing skips, 0 failures; server: 35/35 (untouched); typecheck clean; lint clean on touched files. Version 1.6.3 + CHANGELOG.

## Behavior note for reviewers
Preserving remote items means a previously-incidental deletion (locally deleting a still-remote item *while also* completing a review) no longer propagates to the backup. This is more consistent with the additive-only design, but is a behavior change for that one path. No deletion-sync mechanism was introduced; genuine deletion propagation would be a separate tombstone design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XK2sxKjRfUxBMqyQHypqLB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XK2sxKjRfUxBMqyQHypqLB)_