### PR TITLE
Replace category dropdowns with searchable type-to-filter combobox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.0] - 2026-07-18
+
+### Added
+- Searchable category dropdowns: every category select (entry form,
+  incomes/expenses category filter, Add bucket) is now a hand-built
+  type-to-filter combobox (`CategorySearchSelect`) with a search box inside
+  the popup, case-insensitive substring filtering, full keyboard support
+  (open with Enter/Space/arrows, navigate with ArrowUp/ArrowDown, commit
+  with Enter, dismiss with Escape), click-outside close, and a
+  "No matching categories" empty state. The closed trigger keeps the exact
+  look of the previous native select and the ARIA 1.2 combobox + listbox
+  pattern; no new dependencies were added
+
+### Changed
+- `CategorySelector` is now a thin adapter over `CategorySearchSelect`,
+  preserving its props contract (`handleChange` still receives an
+  event-like `{ currentTarget: { value, name } }`, values keep the
+  `,category,` format and `""` for the empty option)
+
+### Tests
+- New unit suite for `CategorySearchSelect` (open/close, filtering,
+  selection, keyboard navigation with clamping, empty state, click-outside,
+  empty-option reset) and new integration tests for type-to-filter entry
+  creation and the no-match empty state
+- Integration tests that drove the old native select via
+  `user.selectOptions` now open the combobox and click the option instead;
+  assertions and intent are unchanged
+- `CategorySelector.test.js.snap` regenerated for the new markup
+
 ## [1.1.0] - 2026-07-10
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Node version is pinned in `.nvmrc`.
 - **`renderApp.tsx`** — renders the full app in a `MemoryRouter` with a fresh Redux store; returns `{ user, store, ...RenderResult }`.
 - **`seed.ts`** — `seedEntries(entries)` writes entries to `localStorage`; `ts(year, month, day?)` builds a Unix-ms timestamp; month constants `JANUARY`–`DECEMBER` (0-indexed).
 - **`navigation.ts`** — `goToPrevMonth(user, expectedTitle)` and `goToNextMonth(user, expectedTitle)`: click the Prev/Next button and wait for the new month heading. Use these instead of inline `findByRole("button", …)` calls so the assertion pattern stays consistent across test files.
+- **`categorySelect.ts`** — `selectCategory(user, categoryName)`: opens the searchable category dropdown (`CategorySearchSelect`) and clicks the matching option. Use this instead of inline `click(combobox)` → `click(option)` pairs whenever a test just needs to pick a category. Its internal `findByRole("option", …)` throws when the category is missing, so option presence is still asserted. Tests that exercise the dropdown *mechanics* (type-to-filter, empty state, keyboard nav) should still drive the control directly.
 
 ## General guidelines for development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/src/components/common/CategorySearchSelect/index.test.tsx
+++ b/src/components/common/CategorySearchSelect/index.test.tsx
@@ -73,6 +73,8 @@ describe("CategorySearchSelect", () => {
       screen.getByRole("option", { name: "Select a category" })
     ).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "Food" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Eating out" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Gym" })).toBeInTheDocument();
   });
 
   it("filters options with a case-insensitive substring match as the user types", async () => {
@@ -193,7 +195,11 @@ describe("CategorySearchSelect", () => {
     render(
       <div>
         <button type="button">Outside</button>
-        <CategorySearchSelect {...defaultProps} onChange={handleChange} />
+        <CategorySearchSelect
+          {...defaultProps}
+          value=",food,"
+          onChange={handleChange}
+        />
       </div>
     );
 
@@ -204,6 +210,8 @@ describe("CategorySearchSelect", () => {
 
     expect(handleChange).not.toHaveBeenCalled();
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    // The pre-existing value survives the dismissal: the trigger still shows it.
+    expect(screen.getByRole("combobox")).toHaveTextContent("Food");
   });
 
   it("re-selecting the empty option resets the value back to empty", async () => {

--- a/src/components/common/CategorySearchSelect/index.test.tsx
+++ b/src/components/common/CategorySearchSelect/index.test.tsx
@@ -1,0 +1,236 @@
+import { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CategorySearchSelect, { CategorySearchOption } from "./index";
+
+const OPTIONS: CategorySearchOption[] = [
+  { value: ",food,", label: "Food" },
+  { value: ",eating out,", label: "Eating out" },
+  { value: ",gym,", label: "Gym" },
+];
+
+const defaultProps = {
+  id: "test-category",
+  name: "categories",
+  value: "",
+  options: OPTIONS,
+  emptyOptionLabel: "Select a category",
+  onChange: () => {},
+};
+
+// Small stateful harness so tests can assert the committed value round-trips
+// into the trigger's displayed label, the way real call sites use the control.
+const ControlledSelect = ({
+  initialValue = "",
+  onChange = () => {},
+}: {
+  initialValue?: string;
+  onChange?: (value: string) => void;
+}) => {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <CategorySearchSelect
+      {...defaultProps}
+      value={value}
+      onChange={(newValue) => {
+        setValue(newValue);
+        onChange(newValue);
+      }}
+    />
+  );
+};
+
+describe("CategorySearchSelect", () => {
+  it("renders closed: trigger shows the empty option label and no options are in the DOM", () => {
+    render(<CategorySearchSelect {...defaultProps} />);
+
+    const trigger = screen.getByRole("combobox");
+    expect(trigger).toHaveTextContent("Select a category");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+  });
+
+  it("shows the selected option's label on the trigger", () => {
+    render(<CategorySearchSelect {...defaultProps} value=",gym," />);
+
+    expect(screen.getByRole("combobox")).toHaveTextContent("Gym");
+  });
+
+  it("opens on click, focuses the search input and lists every option plus the empty one", async () => {
+    const user = userEvent.setup();
+    render(<CategorySearchSelect {...defaultProps} />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getByRole("combobox")).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(screen.getByLabelText("Search categories")).toHaveFocus();
+    expect(screen.getAllByRole("option")).toHaveLength(4);
+    expect(
+      screen.getByRole("option", { name: "Select a category" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Food" })).toBeInTheDocument();
+  });
+
+  it("filters options with a case-insensitive substring match as the user types", async () => {
+    const user = userEvent.setup();
+    render(<CategorySearchSelect {...defaultProps} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.keyboard("EAT");
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent("Eating out");
+    expect(screen.queryByRole("option", { name: "Gym" })).not.toBeInTheDocument();
+  });
+
+  it("commits a filtered option on click: fires onChange, closes and updates the trigger label", async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    render(<ControlledSelect onChange={handleChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.keyboard("eat");
+    await user.click(screen.getByRole("option", { name: "Eating out" }));
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith(",eating out,");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveTextContent("Eating out");
+    expect(screen.getByRole("combobox")).toHaveFocus();
+  });
+
+  it("shows an empty state when nothing matches, and Enter commits nothing", async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    render(
+      <CategorySearchSelect {...defaultProps} onChange={handleChange} />
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.keyboard("zzzz");
+
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+    expect(screen.getByText("No matching categories")).toBeInTheDocument();
+
+    await user.keyboard("{Enter}");
+    expect(handleChange).not.toHaveBeenCalled();
+    // The panel stays open — nothing was committed.
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+
+  it("supports full keyboard flow: Enter opens, arrows move the highlight, Enter commits", async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    render(<ControlledSelect onChange={handleChange} />);
+
+    screen.getByRole("combobox").focus();
+    await user.keyboard("{Enter}");
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    // Highlight starts on the (selected) empty option; two ArrowDowns land on
+    // the second real option.
+    await user.keyboard("{ArrowDown}{ArrowDown}");
+    const searchInput = screen.getByLabelText("Search categories");
+    expect(searchInput).toHaveAttribute(
+      "aria-activedescendant",
+      "test-category-option-2"
+    );
+
+    await user.keyboard("{Enter}");
+    expect(handleChange).toHaveBeenCalledWith(",eating out,");
+    expect(screen.getByRole("combobox")).toHaveTextContent("Eating out");
+    expect(screen.getByRole("combobox")).toHaveFocus();
+  });
+
+  it("clamps keyboard navigation at both ends (no wraparound)", async () => {
+    const user = userEvent.setup();
+    render(<CategorySearchSelect {...defaultProps} />);
+
+    await user.click(screen.getByRole("combobox"));
+    const searchInput = screen.getByLabelText("Search categories");
+
+    await user.keyboard("{ArrowUp}");
+    expect(searchInput).toHaveAttribute(
+      "aria-activedescendant",
+      "test-category-option-0"
+    );
+
+    await user.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}");
+    expect(searchInput).toHaveAttribute(
+      "aria-activedescendant",
+      "test-category-option-3"
+    );
+  });
+
+  it("closes on Escape without changing the value and refocuses the trigger", async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    render(
+      <CategorySearchSelect
+        {...defaultProps}
+        value=",food,"
+        onChange={handleChange}
+      />
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.keyboard("{Escape}");
+
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveTextContent("Food");
+    expect(screen.getByRole("combobox")).toHaveFocus();
+  });
+
+  it("closes when clicking outside without changing the value", async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    render(
+      <div>
+        <button type="button">Outside</button>
+        <CategorySearchSelect {...defaultProps} onChange={handleChange} />
+      </div>
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("re-selecting the empty option resets the value back to empty", async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+    render(<ControlledSelect initialValue=",gym," onChange={handleChange} />);
+
+    expect(screen.getByRole("combobox")).toHaveTextContent("Gym");
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: "Select a category" }));
+
+    expect(handleChange).toHaveBeenCalledWith("");
+    expect(screen.getByRole("combobox")).toHaveTextContent("Select a category");
+  });
+
+  it("marks the committed value as selected, distinct from the highlight", async () => {
+    const user = userEvent.setup();
+    render(<CategorySearchSelect {...defaultProps} value=",gym," />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(
+      screen.getByRole("option", { name: "Gym" })
+    ).toHaveAttribute("aria-selected", "true");
+    expect(
+      screen.getByRole("option", { name: "Food" })
+    ).toHaveAttribute("aria-selected", "false");
+  });
+});

--- a/src/components/common/CategorySearchSelect/index.tsx
+++ b/src/components/common/CategorySearchSelect/index.tsx
@@ -1,0 +1,274 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import "./styles.scss";
+
+export type CategorySearchOption = {
+  value: string;
+  label: string;
+};
+
+type CategorySearchSelectProps = {
+  /** Same id the surrounding Form.Label already points at (htmlFor). */
+  id: string;
+  name: string;
+  /** Currently selected value ("" = empty option). */
+  value: string;
+  /** Pre-built options; must NOT include the empty option itself. */
+  options: CategorySearchOption[];
+  /** "Select a category" | "All incomes" | "All expenses" | ... */
+  emptyOptionLabel: string;
+  /** Called with the committed raw value on selection. */
+  onChange: (value: string) => void;
+  className?: string;
+  /** Search input placeholder. */
+  placeholder?: string;
+};
+
+const OPEN_KEYS = ["Enter", " ", "ArrowDown", "ArrowUp"];
+
+/**
+ * Searchable replacement for the native category <select> (type-to-filter,
+ * W3Schools filter-dropdown UX). Hand-built on the ARIA 1.2 combobox +
+ * listbox popup pattern: the trigger looks exactly like `select.form-control`,
+ * the popup panel holds a search input that filters the option rows with a
+ * case-insensitive substring match. See the design spec for the full anatomy.
+ */
+const CategorySearchSelect = ({
+  id,
+  name,
+  value,
+  options,
+  emptyOptionLabel,
+  onChange,
+  className = "",
+  placeholder = "Search categories…",
+}: CategorySearchSelectProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // The empty option is a real row, always first, and subject to the same
+  // filter as every other row.
+  const allRows: CategorySearchOption[] = useMemo(
+    () => [{ value: "", label: emptyOptionLabel }, ...options],
+    [emptyOptionLabel, options]
+  );
+
+  const filteredRows = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) return allRows;
+    return allRows.filter((row) =>
+      row.label.toLowerCase().includes(normalizedQuery)
+    );
+  }, [allRows, query]);
+
+  const selectedRow = allRows.find((row) => row.value === value);
+  const selectedLabel = selectedRow ? selectedRow.label : emptyOptionLabel;
+
+  const openPanel = useCallback(() => {
+    const selectedIndex = allRows.findIndex((row) => row.value === value);
+    setQuery("");
+    setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    setIsOpen(true);
+  }, [allRows, value]);
+
+  const closePanel = useCallback((shouldRefocusTrigger = true) => {
+    setIsOpen(false);
+    if (shouldRefocusTrigger) triggerRef.current?.focus();
+  }, []);
+
+  const commitOption = useCallback(
+    (row: CategorySearchOption) => {
+      onChange(row.value);
+      closePanel();
+    },
+    [onChange, closePanel]
+  );
+
+  // Focus goes into the search input as soon as the panel opens.
+  useEffect(() => {
+    if (isOpen) searchRef.current?.focus();
+  }, [isOpen]);
+
+  // Click-outside closes the panel without changing the value. Attached only
+  // while open, so there is no document-wide listener cost when idle.
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const handleDocumentMouseDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleDocumentMouseDown);
+    return () =>
+      document.removeEventListener("mousedown", handleDocumentMouseDown);
+  }, [isOpen]);
+
+  // Keep the highlighted row visible when navigating with the keyboard.
+  useEffect(() => {
+    if (!isOpen || filteredRows.length === 0) return;
+    const highlightedElement = listRef.current?.children[
+      highlightedIndex
+    ] as HTMLElement | undefined;
+    // scrollIntoView is unavailable in jsdom, hence the optional call.
+    highlightedElement?.scrollIntoView?.({ block: "nearest" });
+  }, [isOpen, highlightedIndex, filteredRows.length]);
+
+  const handleTriggerClick = () => {
+    if (isOpen) {
+      closePanel();
+    } else {
+      openPanel();
+    }
+  };
+
+  const handleTriggerKeyDown = (event: React.KeyboardEvent) => {
+    if (OPEN_KEYS.includes(event.key)) {
+      event.preventDefault();
+      if (!isOpen) openPanel();
+    }
+  };
+
+  const handleQueryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(event.currentTarget.value);
+    // Highlight resets to the first row of the filtered set on each keystroke.
+    setHighlightedIndex(0);
+  };
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent) => {
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setHighlightedIndex((index) =>
+          Math.min(index + 1, filteredRows.length - 1)
+        );
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setHighlightedIndex((index) => Math.max(index - 1, 0));
+        break;
+      case "Enter": {
+        // preventDefault always: the control lives inside forms and Enter
+        // must never submit them from the search box.
+        event.preventDefault();
+        const highlightedRow = filteredRows[highlightedIndex];
+        if (highlightedRow) commitOption(highlightedRow);
+        break;
+      }
+      case "Escape":
+        event.preventDefault();
+        closePanel();
+        break;
+      case "Tab":
+        // Close without trapping focus; let the browser move it naturally.
+        closePanel(false);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const triggerClassName = [
+    "form-control",
+    "category-search-select__trigger",
+    isOpen ? "category-search-select__trigger--open" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={`category-search-select ${className}`.trim()}
+      ref={rootRef}
+    >
+      <div
+        id={id}
+        ref={triggerRef}
+        className={triggerClassName}
+        role="combobox"
+        tabIndex={0}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={`${id}-listbox`}
+        aria-labelledby={`${id}-label`}
+        onClick={handleTriggerClick}
+        onKeyDown={handleTriggerKeyDown}
+      >
+        <span className="category-search-select__value">{selectedLabel}</span>
+      </div>
+      {isOpen && (
+        <div className="category-search-select__panel">
+          <div className="category-search-select__search-wrap">
+            <input
+              ref={searchRef}
+              type="text"
+              className="form-control text category-search-select__search"
+              placeholder={placeholder}
+              aria-label="Search categories"
+              aria-activedescendant={
+                filteredRows[highlightedIndex]
+                  ? `${id}-option-${highlightedIndex}`
+                  : undefined
+              }
+              value={query}
+              onChange={handleQueryChange}
+              onKeyDown={handleSearchKeyDown}
+            />
+          </div>
+          <ul
+            ref={listRef}
+            className="category-search-select__options"
+            role="listbox"
+            id={`${id}-listbox`}
+            aria-label={name}
+          >
+            {filteredRows.length === 0 ? (
+              <li className="category-search-select__empty-state">
+                No matching categories
+              </li>
+            ) : (
+              filteredRows.map((row, index) => {
+                const optionClassName = [
+                  "category-search-select__option",
+                  index === highlightedIndex
+                    ? "category-search-select__option--highlighted"
+                    : "",
+                  row.value === value
+                    ? "category-search-select__option--selected"
+                    : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ");
+                return (
+                  <li
+                    key={row.value === "" ? "__empty-option__" : row.value}
+                    id={`${id}-option-${index}`}
+                    role="option"
+                    aria-selected={row.value === value}
+                    className={optionClassName}
+                    onClick={() => commitOption(row)}
+                    onMouseEnter={() => setHighlightedIndex(index)}
+                  >
+                    {row.label}
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CategorySearchSelect;

--- a/src/components/common/CategorySearchSelect/index.tsx
+++ b/src/components/common/CategorySearchSelect/index.tsx
@@ -191,6 +191,8 @@ const CategorySearchSelect = ({
       className={`category-search-select ${className}`.trim()}
       ref={rootRef}
     >
+      {/* aria-controls is only emitted while the listbox is mounted so the
+          IDREF never dangles for a11y linters/AT while closed. */}
       <div
         id={id}
         ref={triggerRef}
@@ -199,7 +201,7 @@ const CategorySearchSelect = ({
         tabIndex={0}
         aria-haspopup="listbox"
         aria-expanded={isOpen}
-        aria-controls={`${id}-listbox`}
+        aria-controls={isOpen ? `${id}-listbox` : undefined}
         aria-labelledby={`${id}-label`}
         onClick={handleTriggerClick}
         onKeyDown={handleTriggerKeyDown}
@@ -209,12 +211,16 @@ const CategorySearchSelect = ({
       {isOpen && (
         <div className="category-search-select__panel">
           <div className="category-search-select__search-wrap">
+            {/* The input holds aria-activedescendant, so it must also declare
+                the listbox it controls for the highlighted option to be
+                announced (ARIA 1.2 list-autocomplete wiring). */}
             <input
               ref={searchRef}
               type="text"
               className="form-control text category-search-select__search"
               placeholder={placeholder}
               aria-label="Search categories"
+              aria-controls={`${id}-listbox`}
               aria-activedescendant={
                 filteredRows[highlightedIndex]
                   ? `${id}-option-${highlightedIndex}`

--- a/src/components/common/CategorySearchSelect/styles.scss
+++ b/src/components/common/CategorySearchSelect/styles.scss
@@ -1,8 +1,5 @@
 @import '../../../variables.scss';
 
-// Chevron affordance, identical to the native select's (global.scss).
-$select-chevron: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%239aa4b2' viewBox='0 0 16 16'%3E%3Cpath d='M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z'/%3E%3C/svg%3E");
-
 .category-search-select {
   position: relative;
   width: 100%;
@@ -29,6 +26,10 @@ $select-chevron: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.
   }
 
   &__value {
+    // min-width: 0 lets the flex item shrink below its content size so long
+    // labels actually ellipsize instead of overflowing past the caret.
+    flex: 1 1 auto;
+    min-width: 0;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/src/components/common/CategorySearchSelect/styles.scss
+++ b/src/components/common/CategorySearchSelect/styles.scss
@@ -1,0 +1,88 @@
+@import '../../../variables.scss';
+
+// Chevron affordance, identical to the native select's (global.scss).
+$select-chevron: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%239aa4b2' viewBox='0 0 16 16'%3E%3Cpath d='M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z'/%3E%3C/svg%3E");
+
+.category-search-select {
+  position: relative;
+  width: 100%;
+
+  // Trigger: same box model as `select.form-control` so the closed control is
+  // visually indistinguishable from the native select it replaces.
+  &__trigger {
+    display: flex;
+    align-items: center;
+    height: 3rem;
+    padding: 0 2.4rem 0 1.1em;
+    cursor: pointer;
+    background-image: $select-chevron;
+    background-repeat: no-repeat;
+    background-position: right 0.9rem center;
+
+    // While the panel is open the trigger reads as "active", matching the
+    // `.form-control:focus` treatment even though DOM focus sits in the
+    // panel's search input.
+    &--open {
+      border-color: $accent;
+      box-shadow: 0 0 0 0.2rem $accent-soft;
+    }
+  }
+
+  &__value {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  // Lightweight non-portal popover; visually consistent with .modal-content.
+  &__panel {
+    position: absolute;
+    top: calc(100% + 0.35rem);
+    left: 0;
+    right: 0;
+    z-index: 20;
+    background-color: $bg-surface;
+    border: 1px solid $border-strong;
+    border-radius: $radius-card;
+    box-shadow: $shadow-pop;
+    overflow: hidden;
+  }
+
+  &__search-wrap {
+    padding: 0.6rem;
+  }
+
+  &__options {
+    // Defensive vh clamp so the mobile keyboard cannot push the whole list
+    // off-screen. Interpolated so libsass passes the CSS min() through
+    // instead of trying (and failing) to compare rem with vh at build time.
+    max-height: #{"min(16rem, 40vh)"};
+    overflow-y: auto;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__option {
+    padding: 0.65rem 1rem;
+    color: $text-primary;
+    cursor: pointer;
+    transition: background-color $transition-quick;
+
+    &--highlighted {
+      background-color: $bg-raised-hover;
+    }
+
+    &--selected {
+      background-color: $accent-soft;
+      color: $text-primary;
+    }
+  }
+
+  &__empty-state {
+    padding: 0.65rem 1rem;
+    color: $text-muted;
+    cursor: default;
+    text-align: center;
+  }
+}

--- a/src/components/common/ExpensesManager/AddBucket/index.js
+++ b/src/components/common/ExpensesManager/AddBucket/index.js
@@ -3,7 +3,8 @@ import { connect } from "react-redux";
 import { withRouter, Link } from "react-router-dom";
 import { Col, Form, Row, Button } from "react-bootstrap";
 import { MainContentContainer } from "../../MainContentContainer";
-import { FormButton, FormContent, FormSelect, InputNumber } from "../../Forms";
+import { FormButton, FormContent, InputNumber } from "../../Forms";
+import CategorySearchSelect from "../../CategorySearchSelect";
 import ContentTileSection from "../../ContentTitleSection";
 import { addBucket } from "../../../../redux/expensesManager/actionCreators";
 import {
@@ -71,27 +72,27 @@ const AddBucket = ({ buckets, unbudgetedCategories, onAddBucket, history }) => {
             <Row className="top-container container-fluid">
               <Col xs={12} className="top-content">
                 <Form.Group>
-                  <Form.Label htmlFor="categoryName">Category</Form.Label>
+                  <Form.Label htmlFor="categoryName" id="categoryName-label">
+                    Category
+                  </Form.Label>
                   <p className="field-hint">
                     Pick one of your existing categories to give it a monthly
                     spending limit.
                   </p>
-                  <FormSelect
+                  <CategorySearchSelect
                     id="categoryName"
                     name="categoryName"
                     value={categoryName}
-                    onChange={(event) => {
-                      setCategoryName(event.currentTarget.value);
+                    emptyOptionLabel="Select a category"
+                    options={categoriesWithoutBucket.map((category) => ({
+                      value: category,
+                      label: category,
+                    }))}
+                    onChange={(newCategoryName) => {
+                      setCategoryName(newCategoryName);
                       setError(null);
                     }}
-                  >
-                    <option value="">Select a category</option>
-                    {categoriesWithoutBucket.map((category) => (
-                      <option value={category} key={category}>
-                        {category}
-                      </option>
-                    ))}
-                  </FormSelect>
+                  />
                 </Form.Group>
                 <Form.Group className="vertical-standard-space">
                   <Form.Label htmlFor="bucket-allowance">

--- a/src/components/common/ExpensesManager/CategorySelector.js
+++ b/src/components/common/ExpensesManager/CategorySelector.js
@@ -1,7 +1,13 @@
-import React from "react";
-import { FormSelect } from "../Forms";
+import React, { useMemo } from "react";
+import CategorySearchSelect from "../CategorySearchSelect";
 
-function CategorySelector({
+/**
+ * Thin adapter around CategorySearchSelect that keeps the historical
+ * CategorySelector contract: `handleChange` still receives an event-like
+ * object exposing `currentTarget.value`/`currentTarget.name`, and values
+ * keep the load-bearing `,category,` format ("" for the empty option).
+ */
+const CategorySelector = ({
   handleChange,
   name,
   value,
@@ -9,25 +15,31 @@ function CategorySelector({
   className = "",
   id,
   emptyOptionLabel,
-}) {
-  return (
-    <FormSelect
-      className={className}
-      name={name}
-      value={value}
-      onChange={handleChange}
-      id={id}
-    >
-      <option value="">{emptyOptionLabel || `All ${name}`}</option>
-      {/** TODO: Revise the set up of the categoryOption.value at this point
-       * Probably a good idea not to make the frontend take care of the logic of the ,, */}
-      {categoryOptions.map((categoryOption, key) => (
-        <option value={`,${categoryOption.value},`} key={key}>
-          {categoryOption.name}
-        </option>
-      ))}
-    </FormSelect>
+}) => {
+  /** TODO: Revise the set up of the categoryOption.value at this point
+   * Probably a good idea not to make the frontend take care of the logic of the ,, */
+  const options = useMemo(
+    () =>
+      categoryOptions.map((categoryOption) => ({
+        value: `,${categoryOption.value},`,
+        label: categoryOption.name,
+      })),
+    [categoryOptions]
   );
-}
+
+  return (
+    <CategorySearchSelect
+      className={className}
+      id={id}
+      name={name}
+      value={value || ""}
+      options={options}
+      emptyOptionLabel={emptyOptionLabel || `All ${name}`}
+      onChange={(newValue) =>
+        handleChange({ currentTarget: { value: newValue, name } })
+      }
+    />
+  );
+};
 
 export default CategorySelector;

--- a/src/components/common/ExpensesManager/CategorySelector.test.js
+++ b/src/components/common/ExpensesManager/CategorySelector.test.js
@@ -8,6 +8,7 @@ it("Renders CategorySelector component properly", () => {
       <CategorySelector
         handleChange={jest.fn()}
         name="CategorySelector"
+        id="category-selector"
         value=""
         categoryOptions={[
           { name: "Cat1", value: "cat1" },

--- a/src/components/common/ExpensesManager/EntryForm/index.js
+++ b/src/components/common/ExpensesManager/EntryForm/index.js
@@ -96,7 +96,9 @@ class EntryForm extends Component {
                 ></InputText>
               </Form.Group>
               <Form.Group className="vertical-standard-space">
-                <Form.Label htmlFor="entry-category">Category</Form.Label>
+                <Form.Label htmlFor="entry-category" id="entry-category-label">
+                  Category
+                </Form.Label>
                 <CategorySelector
                   id="entry-category"
                   name="categories"

--- a/src/components/common/ExpensesManager/Summaries/EntriesSummaryWithFilter/index.js
+++ b/src/components/common/ExpensesManager/Summaries/EntriesSummaryWithFilter/index.js
@@ -63,7 +63,11 @@ class EntrySummaryWithFilter extends Component {
             {`${capitalize(entryTypePlural)} total: ${formatNumberForDisplay(totalSum)}`}
           </ContentTileSection>
           {/* TODO: Add the selectedDate display here for letting the user know which year and month he is looking or working at */}
-          <label className="form-label" htmlFor="category-filter">
+          <label
+            className="form-label"
+            htmlFor="category-filter"
+            id="category-filter-label"
+          >
             Filter by category
           </label>
           <CategorySelector

--- a/src/components/common/ExpensesManager/__snapshots__/CategorySelector.test.js.snap
+++ b/src/components/common/ExpensesManager/__snapshots__/CategorySelector.test.js.snap
@@ -1,26 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Renders CategorySelector component properly 1`] = `
-<select
-  className="form-control"
-  name="CategorySelector"
-  onChange={[MockFunction]}
-  value=""
+<div
+  className="category-search-select"
 >
-  <option
-    value=""
+  <div
+    aria-controls="category-selector-listbox"
+    aria-expanded={false}
+    aria-haspopup="listbox"
+    aria-labelledby="category-selector-label"
+    className="form-control category-search-select__trigger"
+    id="category-selector"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="combobox"
+    tabIndex={0}
   >
-    All CategorySelector
-  </option>
-  <option
-    value=",cat1,"
-  >
-    Cat1
-  </option>
-  <option
-    value=",cat2,"
-  >
-    Cat2
-  </option>
-</select>
+    <span
+      className="category-search-select__value"
+    >
+      All CategorySelector
+    </span>
+  </div>
+</div>
 `;

--- a/src/components/common/ExpensesManager/__snapshots__/CategorySelector.test.js.snap
+++ b/src/components/common/ExpensesManager/__snapshots__/CategorySelector.test.js.snap
@@ -5,7 +5,6 @@ exports[`Renders CategorySelector component properly 1`] = `
   className="category-search-select"
 >
   <div
-    aria-controls="category-selector-listbox"
     aria-expanded={false}
     aria-haspopup="listbox"
     aria-labelledby="category-selector-label"

--- a/src/global.scss
+++ b/src/global.scss
@@ -58,8 +58,8 @@ select.form-control {
   height: 3rem;
   padding: 0 2.4rem 0 1.1em;
   appearance: none;
-  // Chevron affordance for the native select.
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%239aa4b2' viewBox='0 0 16 16'%3E%3Cpath d='M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z'/%3E%3C/svg%3E");
+  // Chevron affordance for the native select (shared token, variables.scss).
+  background-image: $select-chevron;
   background-repeat: no-repeat;
   background-position: right 0.9rem center;
 }

--- a/src/integrationTests/categoryBucketCreation.test.tsx
+++ b/src/integrationTests/categoryBucketCreation.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { renderApp } from "./helpers/renderApp";
+import { selectCategory } from "./helpers/categorySelect";
 
 // Pinned so the navigable month header reads a stable "May 2026".
 const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
@@ -41,9 +42,7 @@ describe("category + bucket creation (issue #100)", () => {
     localStorage.setItem("categories", JSON.stringify(["Gym"]));
     const { user } = await renderApp("/add-bucket");
 
-    await user.click(screen.getByRole("combobox"));
-    expect(await screen.findByRole("option", { name: "Gym" })).toBeInTheDocument();
-    await user.click(screen.getByRole("option", { name: "Gym" }));
+    await selectCategory(user, "Gym");
     await user.type(
       screen.getByPlaceholderText(/insert bucket allowance/i),
       "120"
@@ -76,10 +75,9 @@ describe("category + bucket creation (issue #100)", () => {
     );
     await user.type(screen.getByPlaceholderText(/description/i), "Monthly pass");
 
-    await user.click(screen.getByRole("combobox"));
-    // The brand new category is available as an option even without a bucket.
-    expect(await screen.findByRole("option", { name: "Gym" })).toBeInTheDocument();
-    await user.click(screen.getByRole("option", { name: "Gym" }));
+    // The brand new category is available as an option even without a bucket;
+    // selectCategory's internal option lookup fails the test if it is missing.
+    await selectCategory(user, "Gym");
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
     // The expense shows on the dashboard.

--- a/src/integrationTests/categoryBucketCreation.test.tsx
+++ b/src/integrationTests/categoryBucketCreation.test.tsx
@@ -41,9 +41,9 @@ describe("category + bucket creation (issue #100)", () => {
     localStorage.setItem("categories", JSON.stringify(["Gym"]));
     const { user } = await renderApp("/add-bucket");
 
-    const categorySelect = screen.getByRole("combobox");
-    expect(screen.getByRole("option", { name: "Gym" })).toBeInTheDocument();
-    await user.selectOptions(categorySelect, "Gym");
+    await user.click(screen.getByRole("combobox"));
+    expect(await screen.findByRole("option", { name: "Gym" })).toBeInTheDocument();
+    await user.click(screen.getByRole("option", { name: "Gym" }));
     await user.type(
       screen.getByPlaceholderText(/insert bucket allowance/i),
       "120"
@@ -76,10 +76,10 @@ describe("category + bucket creation (issue #100)", () => {
     );
     await user.type(screen.getByPlaceholderText(/description/i), "Monthly pass");
 
-    const categorySelect = screen.getByRole("combobox");
+    await user.click(screen.getByRole("combobox"));
     // The brand new category is available as an option even without a bucket.
-    expect(screen.getByRole("option", { name: "Gym" })).toBeInTheDocument();
-    await user.selectOptions(categorySelect, "Gym");
+    expect(await screen.findByRole("option", { name: "Gym" })).toBeInTheDocument();
+    await user.click(screen.getByRole("option", { name: "Gym" }));
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
     // The expense shows on the dashboard.

--- a/src/integrationTests/dataReading.test.tsx
+++ b/src/integrationTests/dataReading.test.tsx
@@ -111,10 +111,8 @@ describe("/incomes route", () => {
     await user.click(await screen.findByText("Incomes"));
 
     // Select "Salary" filter
-    await user.selectOptions(
-      await screen.findByRole("combobox"),
-      "Salary"
-    );
+    await user.click(await screen.findByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Salary" }));
 
     // Only the salary entry is shown
     expect(await screen.findByText(/paycheck/i)).toBeInTheDocument();
@@ -151,10 +149,8 @@ describe("/expenses route", () => {
     await user.click(await screen.findByText("Expenses"));
 
     // Select "Food" filter
-    await user.selectOptions(
-      await screen.findByRole("combobox"),
-      "Food"
-    );
+    await user.click(await screen.findByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Food" }));
 
     // Only the food entry is shown
     expect(await screen.findByText(/supermarket/i)).toBeInTheDocument();

--- a/src/integrationTests/dataReading.test.tsx
+++ b/src/integrationTests/dataReading.test.tsx
@@ -1,6 +1,7 @@
 import { screen, within } from "@testing-library/react";
 import { renderApp } from "./helpers/renderApp";
 import { seedEntries, ts, MARCH, APRIL, MAY } from "./helpers/seed";
+import { selectCategory } from "./helpers/categorySelect";
 
 const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
 
@@ -111,8 +112,7 @@ describe("/incomes route", () => {
     await user.click(await screen.findByText("Incomes"));
 
     // Select "Salary" filter
-    await user.click(await screen.findByRole("combobox"));
-    await user.click(await screen.findByRole("option", { name: "Salary" }));
+    await selectCategory(user, "Salary");
 
     // Only the salary entry is shown
     expect(await screen.findByText(/paycheck/i)).toBeInTheDocument();
@@ -149,8 +149,7 @@ describe("/expenses route", () => {
     await user.click(await screen.findByText("Expenses"));
 
     // Select "Food" filter
-    await user.click(await screen.findByRole("combobox"));
-    await user.click(await screen.findByRole("option", { name: "Food" }));
+    await selectCategory(user, "Food");
 
     // Only the food entry is shown
     expect(await screen.findByText(/supermarket/i)).toBeInTheDocument();

--- a/src/integrationTests/entryCreation.test.tsx
+++ b/src/integrationTests/entryCreation.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import { renderApp } from "./helpers/renderApp";
 import { seedEntries, ts, FEBRUARY } from "./helpers/seed";
+import { selectCategory } from "./helpers/categorySelect";
 
 const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
 
@@ -25,8 +26,7 @@ describe("entry creation", () => {
       "75"
     );
     await user.type(screen.getByPlaceholderText(/description/i), "Test meal");
-    await user.click(screen.getByRole("combobox"));
-    await user.click(await screen.findByRole("option", { name: "Eating out" }));
+    await selectCategory(user, "Eating out");
 
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
@@ -44,8 +44,7 @@ describe("entry creation", () => {
       "1000"
     );
     await user.type(screen.getByPlaceholderText(/description/i), "Monthly pay");
-    await user.click(screen.getByRole("combobox"));
-    await user.click(await screen.findByRole("option", { name: "Salary" }));
+    await selectCategory(user, "Salary");
 
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
@@ -64,8 +63,7 @@ describe("entry creation", () => {
     await user.click(await screen.findByRole("link", { name: /add expenses/i }));
     await user.type(await screen.findByPlaceholderText(/insert expense amount/i), "50");
     await user.type(screen.getByPlaceholderText(/description/i), "Groceries");
-    await user.click(screen.getByRole("combobox"));
-    await user.click(await screen.findByRole("option", { name: "Food" }));
+    await selectCategory(user, "Food");
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
     // Navigate to /expenses and click the newly created entry to edit it
@@ -146,8 +144,7 @@ describe("entry creation", () => {
     await user.click(await screen.findByRole("link", { name: /add expenses/i }));
     await user.type(await screen.findByPlaceholderText(/insert expense amount/i), "99");
     await user.type(screen.getByPlaceholderText(/description/i), "Feb Rent");
-    await user.click(screen.getByRole("combobox"));
-    await user.click(await screen.findByRole("option", { name: "Food" }));
+    await selectCategory(user, "Food");
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
     // Before refresh: dashboard should be in February showing the new expense

--- a/src/integrationTests/entryCreation.test.tsx
+++ b/src/integrationTests/entryCreation.test.tsx
@@ -25,7 +25,8 @@ describe("entry creation", () => {
       "75"
     );
     await user.type(screen.getByPlaceholderText(/description/i), "Test meal");
-    await user.selectOptions(screen.getByRole("combobox"), "Eating out");
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Eating out" }));
 
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
@@ -43,7 +44,8 @@ describe("entry creation", () => {
       "1000"
     );
     await user.type(screen.getByPlaceholderText(/description/i), "Monthly pay");
-    await user.selectOptions(screen.getByRole("combobox"), "Salary");
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Salary" }));
 
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
@@ -62,7 +64,8 @@ describe("entry creation", () => {
     await user.click(await screen.findByRole("link", { name: /add expenses/i }));
     await user.type(await screen.findByPlaceholderText(/insert expense amount/i), "50");
     await user.type(screen.getByPlaceholderText(/description/i), "Groceries");
-    await user.selectOptions(screen.getByRole("combobox"), "Food");
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Food" }));
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
     // Navigate to /expenses and click the newly created entry to edit it
@@ -76,6 +79,50 @@ describe("entry creation", () => {
 
     expect(await screen.findByText("$75.00")).toBeInTheDocument();
     expect(screen.queryByText("$50.00")).not.toBeInTheDocument();
+  });
+
+  it("user can type to filter the category dropdown and pick the narrowed option", async () => {
+    const { user } = await renderApp("/");
+
+    await user.click(await screen.findByRole("link", { name: /add expenses/i }));
+    await user.type(
+      await screen.findByPlaceholderText(/insert expense amount/i),
+      "42"
+    );
+
+    // Open the searchable dropdown; focus lands in its search box.
+    await user.click(screen.getByRole("combobox"));
+    expect(await screen.findByLabelText(/search categories/i)).toHaveFocus();
+
+    // Typing narrows the visible options down to the single match.
+    await user.keyboard("eating");
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent("Eating out");
+
+    // Selecting the filtered option closes the panel and shows the choice.
+    await user.click(options[0]);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveTextContent("Eating out");
+
+    await user.click(screen.getByRole("button", { name: /submit/i }));
+    expect(await screen.findByText("$42.00")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the category search matches nothing", async () => {
+    const { user } = await renderApp("/");
+
+    await user.click(await screen.findByRole("link", { name: /add expenses/i }));
+    await user.click(await screen.findByRole("combobox"));
+    await user.keyboard("definitely-not-a-category");
+
+    expect(await screen.findByText(/no matching categories/i)).toBeInTheDocument();
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+
+    // Escape closes the panel without committing anything.
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveTextContent("Select a category");
   });
 
   it("entry added while viewing a previous month is stored in that month and survives a page refresh", async () => {
@@ -99,7 +146,8 @@ describe("entry creation", () => {
     await user.click(await screen.findByRole("link", { name: /add expenses/i }));
     await user.type(await screen.findByPlaceholderText(/insert expense amount/i), "99");
     await user.type(screen.getByPlaceholderText(/description/i), "Feb Rent");
-    await user.selectOptions(screen.getByRole("combobox"), "Food");
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Food" }));
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
     // Before refresh: dashboard should be in February showing the new expense

--- a/src/integrationTests/fixedEntries.test.tsx
+++ b/src/integrationTests/fixedEntries.test.tsx
@@ -38,10 +38,8 @@ const addRecurringExpense = async (
     amount
   );
   await user.type(screen.getByPlaceholderText(/description/i), description);
-  await user.selectOptions(
-    screen.getByRole("combobox"),
-    screen.getByRole("option", { name: "Food" })
-  );
+  await user.click(screen.getByRole("combobox"));
+  await user.click(await screen.findByRole("option", { name: "Food" }));
   await user.click(screen.getByLabelText(/recurring/i));
   await user.click(screen.getByRole("button", { name: /submit/i }));
   // Back on the dashboard after submitting.
@@ -60,10 +58,8 @@ const addRecurringIncome = async (
     amount
   );
   await user.type(screen.getByPlaceholderText(/description/i), description);
-  await user.selectOptions(
-    screen.getByRole("combobox"),
-    screen.getByRole("option", { name: "Salary" })
-  );
+  await user.click(screen.getByRole("combobox"));
+  await user.click(await screen.findByRole("option", { name: "Salary" }));
   await user.click(screen.getByLabelText(/recurring/i));
   await user.click(screen.getByRole("button", { name: /submit/i }));
   // Back on the dashboard after submitting.
@@ -81,10 +77,8 @@ const addRegularExpense = async (
     amount
   );
   await user.type(screen.getByPlaceholderText(/description/i), description);
-  await user.selectOptions(
-    screen.getByRole("combobox"),
-    screen.getByRole("option", { name: "Food" })
-  );
+  await user.click(screen.getByRole("combobox"));
+  await user.click(await screen.findByRole("option", { name: "Food" }));
   // Recurring toggle is intentionally NOT clicked.
   await user.click(screen.getByRole("button", { name: /submit/i }));
   await screen.findByRole("link", { name: /add expenses/i });

--- a/src/integrationTests/fixedEntries.test.tsx
+++ b/src/integrationTests/fixedEntries.test.tsx
@@ -3,6 +3,7 @@ import { UserEvent } from "@testing-library/user-event";
 import { renderApp } from "./helpers/renderApp";
 import { seedEntries, ts, MARCH } from "./helpers/seed";
 import { goToPrevMonth, goToNextMonth } from "./helpers/navigation";
+import { selectCategory } from "./helpers/categorySelect";
 
 // Pinned so "today" is May 2026 and the navigable header reads stable months.
 const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
@@ -38,8 +39,7 @@ const addRecurringExpense = async (
     amount
   );
   await user.type(screen.getByPlaceholderText(/description/i), description);
-  await user.click(screen.getByRole("combobox"));
-  await user.click(await screen.findByRole("option", { name: "Food" }));
+  await selectCategory(user, "Food");
   await user.click(screen.getByLabelText(/recurring/i));
   await user.click(screen.getByRole("button", { name: /submit/i }));
   // Back on the dashboard after submitting.
@@ -58,8 +58,7 @@ const addRecurringIncome = async (
     amount
   );
   await user.type(screen.getByPlaceholderText(/description/i), description);
-  await user.click(screen.getByRole("combobox"));
-  await user.click(await screen.findByRole("option", { name: "Salary" }));
+  await selectCategory(user, "Salary");
   await user.click(screen.getByLabelText(/recurring/i));
   await user.click(screen.getByRole("button", { name: /submit/i }));
   // Back on the dashboard after submitting.
@@ -77,8 +76,7 @@ const addRegularExpense = async (
     amount
   );
   await user.type(screen.getByPlaceholderText(/description/i), description);
-  await user.click(screen.getByRole("combobox"));
-  await user.click(await screen.findByRole("option", { name: "Food" }));
+  await selectCategory(user, "Food");
   // Recurring toggle is intentionally NOT clicked.
   await user.click(screen.getByRole("button", { name: /submit/i }));
   await screen.findByRole("link", { name: /add expenses/i });

--- a/src/integrationTests/helpers/categorySelect.ts
+++ b/src/integrationTests/helpers/categorySelect.ts
@@ -1,0 +1,16 @@
+import { screen } from "@testing-library/react";
+import { renderApp } from "./renderApp";
+
+type User = Awaited<ReturnType<typeof renderApp>>["user"];
+
+/**
+ * Picks a category from the searchable category dropdown (CategorySearchSelect):
+ * opens the combobox and clicks the matching option, mirroring what a real user
+ * does. Use this instead of inline open-then-click calls so the interaction stays
+ * consistent across test files. The internal `findByRole("option", ...)` throws
+ * when the category is absent, so presence is still asserted.
+ */
+export async function selectCategory(user: User, categoryName: string): Promise<void> {
+  await user.click(await screen.findByRole("combobox"));
+  await user.click(await screen.findByRole("option", { name: categoryName }));
+}

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -68,6 +68,11 @@ $nav-breakpoint: 768px; // below this the nav becomes the bottom tab bar
 $shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3);
 $shadow-pop: 0 12px 32px rgba(0, 0, 0, 0.45);
 
+// Chevron affordance shared by the native selects (global.scss) and the
+// searchable category dropdown's trigger (CategorySearchSelect) — single
+// source of truth so the two can never drift.
+$select-chevron: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%239aa4b2' viewBox='0 0 16 16'%3E%3Cpath d='M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z'/%3E%3C/svg%3E");
+
 $transition-quick: 140ms ease;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Replaces every category dropdown with a searchable type-to-filter control (W3Schools filter-dropdown UX) to reduce friction when inputting entries.

## What changed

- New `CategorySearchSelect` component (`.tsx`, no new dependencies): trigger styled identically to the existing native selects, popup with a search input that filters options via case-insensitive substring match, full keyboard support (arrows/Enter/Escape/Tab), click-outside close, ARIA 1.2 combobox pattern, and a "No matching categories" empty state.
- Replaced in all three category dropdown locations: `CategorySelector` (Add/Edit entry forms and the `/incomes`–`/expenses` category filter) and `AddBucket`. The Summary page's entry-type select is not a category dropdown and stays native.
- Value semantics and the `handleChange` event contract are preserved (`,category,` paths, `""` empty option), so no call-site logic changed.
- Chevron icon extracted to a shared `$select-chevron` SCSS token used by both native selects and the new control.

## Tests

- New unit suite for `CategorySearchSelect` (open/close, filtering, selection, keyboard nav, empty state, click-outside) plus 2 new integration tests for type-to-filter entry creation.
- Existing integration tests only changed where strictly necessary: `user.selectOptions` interactions rewritten as open-then-click since the control is no longer a native `<select>`; assertions unchanged.
- Full suite: 157 passed / 14 pre-existing skips; typecheck clean; lint identical to baseline. Manually verified in-browser at a mobile viewport (21/21 QA cases).

Version bumped to 1.2.0 with a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoyvDS1D42LYSoov4PUVG9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoyvDS1D42LYSoov4PUVG9)_