### PR TITLE
Fix category filter for names containing regex-special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.1] - 2026-07-19
+
+### Fixed
+- Category filter on the incomes/expenses report no longer breaks for
+  categories whose name contains regex-special characters (e.g.
+  "House (Rent)"). `getFilteredEntriesByCategory` used
+  `categories_path.match(category)`, which treated the selected category
+  value as a regular expression, so the parentheses in "House (Rent)" were
+  parsed as a capture group and never matched the stored
+  `,house (rent),` path. It now matches the category value literally with
+  `String.prototype.includes`
+
 ## [1.2.0] - 2026-07-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/src/helpers/entriesHelper/entriesHelper.js
+++ b/src/helpers/entriesHelper/entriesHelper.js
@@ -27,7 +27,7 @@ function getFilteredEntriesByCategory({
   const entriesToFilter =
     entries[selectedYear]?.[selectedMonth]?.[entryTypePlural];
   return category.length
-    ? entriesToFilter.filter((entry) => entry.categories_path.match(category))
+    ? entriesToFilter.filter((entry) => entry.categories_path.includes(category))
     : entriesToFilter || [];
 }
 

--- a/src/integrationTests/dataReading.test.tsx
+++ b/src/integrationTests/dataReading.test.tsx
@@ -155,6 +155,24 @@ describe("/expenses route", () => {
     expect(await screen.findByText(/supermarket/i)).toBeInTheDocument();
     expect(screen.queryByText(/lunch/i)).not.toBeInTheDocument();
   });
+
+  it("filters expenses by a category whose name contains parentheses", async () => {
+    seedEntries([
+      { date: ts(2026, MAY), amount: "800", type: "expense", categories_path: ",house (rent),", description: "Monthly Rent" },
+      { date: ts(2026, MAY), amount: "30",  type: "expense", categories_path: ",eating out,",   description: "Lunch" },
+    ]);
+
+    const { user } = await renderApp("/");
+
+    await user.click(await screen.findByText("Expenses"));
+
+    // Select the "House (Rent)" filter — its parentheses used to be treated as
+    // regex metacharacters, so the rent entry never showed up.
+    await selectCategory(user, "House (Rent)");
+
+    expect(await screen.findByText(/monthly rent/i)).toBeInTheDocument();
+    expect(screen.queryByText(/lunch/i)).not.toBeInTheDocument();
+  });
 });
 
 describe("/incomes route - past months", () => {

--- a/src/integrationTests/dataReading.test.tsx
+++ b/src/integrationTests/dataReading.test.tsx
@@ -2,6 +2,12 @@ import { screen, within } from "@testing-library/react";
 import { renderApp } from "./helpers/renderApp";
 import { seedEntries, ts, MARCH, APRIL, MAY } from "./helpers/seed";
 import { selectCategory } from "./helpers/categorySelect";
+import { getEntryCategoryOption } from "../helpers/entriesHelper/entriesHelper";
+
+// The full seed list of selectable expense categories, derived straight from
+// the app so the coverage below can never drift from what the UI offers.
+const EXPENSE_CATEGORIES: Array<{ name: string; value: string }> =
+  getEntryCategoryOption("expense");
 
 const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
 
@@ -156,23 +162,33 @@ describe("/expenses route", () => {
     expect(screen.queryByText(/lunch/i)).not.toBeInTheDocument();
   });
 
-  it("filters expenses by a category whose name contains parentheses", async () => {
-    seedEntries([
-      { date: ts(2026, MAY), amount: "800", type: "expense", categories_path: ",house (rent),", description: "Monthly Rent" },
-      { date: ts(2026, MAY), amount: "30",  type: "expense", categories_path: ",eating out,",   description: "Lunch" },
-    ]);
+  // Regression coverage for the regex-in-filter bug: the category value used
+  // to be passed to `String.prototype.match`, so any name with regex-special
+  // characters (e.g. "House (Rent)") never matched. Exercising every seeded
+  // category guarantees the filter matches literally for all of them.
+  it.each(EXPENSE_CATEGORIES.map(({ name, value }) => [name, value]))(
+    'filters expenses by the "%s" category',
+    async (categoryName, categoryValue) => {
+      // A decoy in a different category that must be filtered out.
+      const decoy = EXPENSE_CATEGORIES.find(
+        ({ value }) => value !== categoryValue
+      )!;
 
-    const { user } = await renderApp("/");
+      seedEntries([
+        { date: ts(2026, MAY), amount: "800", type: "expense", categories_path: `,${categoryValue},`, description: "Target Entry" },
+        { date: ts(2026, MAY), amount: "30",  type: "expense", categories_path: `,${decoy.value},`,  description: "Decoy Entry" },
+      ]);
 
-    await user.click(await screen.findByText("Expenses"));
+      const { user } = await renderApp("/");
 
-    // Select the "House (Rent)" filter — its parentheses used to be treated as
-    // regex metacharacters, so the rent entry never showed up.
-    await selectCategory(user, "House (Rent)");
+      await user.click(await screen.findByText("Expenses"));
 
-    expect(await screen.findByText(/monthly rent/i)).toBeInTheDocument();
-    expect(screen.queryByText(/lunch/i)).not.toBeInTheDocument();
-  });
+      await selectCategory(user, categoryName);
+
+      expect(await screen.findByText(/target entry/i)).toBeInTheDocument();
+      expect(screen.queryByText(/decoy entry/i)).not.toBeInTheDocument();
+    }
+  );
 });
 
 describe("/incomes route - past months", () => {


### PR DESCRIPTION
## Problem

Filtering expenses (or incomes) by the "House (Rent)" category returned no entries, even when matching entries existed.

## Cause

`getFilteredEntriesByCategory` used `entry.categories_path.match(category)`. `String.prototype.match()` coerces its argument into a **regular expression**, so the selected value `,house (rent),` was parsed with `(rent)` as a regex capture group — effectively searching for `,house rent,` and never matching the literally-stored `,house (rent),` path. Other categories worked only because their names contain no regex-special characters.

## Fix

Match the category value literally with `String.prototype.includes` instead of `.match`.

## Tests
- Added a regression integration test in `dataReading.test.tsx` seeding a `,house (rent),` expense and asserting the "House (Rent)" filter shows it.
- `npm test -- --testPathPattern="integrationTests"` → 72/72 pass
- `npm run typecheck` → clean

Bumped version to `1.2.1` with a matching `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124hMyXjYD4zUPPYpbGRK4F

---
_Generated by [Claude Code](https://claude.ai/code/session_0124hMyXjYD4zUPPYpbGRK4F)_