### PR TITLE
PR 3 — /summary: one filter state drives both lists, net filtered total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.0] - 2026-07-20
+
+### Added
+- Filters & sorting on the monthly summary (/summary): the shared toolbar
+  (live search, sort, Filters button) and the Filters sheet/panel now render
+  on the summary screen, and the ONE shared filter/sort state drives BOTH
+  the incomes and the expenses lists simultaneously — a filter set on
+  /expenses or /incomes is already active when navigating to /summary and
+  vice versa
+- Gold banner variant for /summary: "Filtered view · both lists" with the
+  combined "N of M entries" across both lists and a signed net filtered
+  total ("Filtered total · net", e.g. "+$3,125.02") — income-green when
+  positive, expense-rose when negative, neutral at zero
+- "Matching incomes" / "Matching expenses" section headers with per-list
+  money totals while filtered (`ListSectionHeader` gained an optional
+  `totalText` shown instead of the entry count)
+- The sheet's category picker on /summary offers income AND expense
+  categories, since one filter drives both lists
+- Combined empty state on /summary when zero entries match across both
+  lists; charts (type doughnut and per-type category charts) recompute
+  against the filtered subsets
+
+### Changed
+- The Summary screen is now Redux-connected (`entryFilters` +
+  setEntryFilters/clearEntryFilters); the "Show" entry-type select is
+  untouched — filters apply within whatever it displays, and the banner
+  keeps reporting both lists
+- Both /summary lists now honor the shared sort key (date-newest-first by
+  default), matching the /expenses and /incomes behavior
+
+### Tests
+- New integration suite `summaryFilters.test.tsx` (11 tests): both-list
+  narrowing from one search, shared sort ordering across lists, income
+  categories in the picker, signed net total with polarity (positive green
+  / negative rose), per-list Matching headers with totals, chip removal
+  and Clear restoring tile + default sort, cross-screen filter carryover
+  from /expenses, "Show" select regression and interplay, and the combined
+  empty state
+
 ## [1.4.0] - 2026-07-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/src/components/common/ExpensesManager/EntryListControls/FilteredBanner.tsx
+++ b/src/components/common/ExpensesManager/EntryListControls/FilteredBanner.tsx
@@ -11,7 +11,9 @@ import "./styles.scss";
 type FilteredBannerProps = {
   descriptors: FilterDescriptor[];
   counts: { shown: number; total: number };
-  /** "Filtered total" on /expenses & /incomes; "Filtered total · net" later. */
+  /** "Filtered view" on the single lists; "Filtered view · both lists" on /summary. */
+  title?: string;
+  /** "Filtered total" on /expenses & /incomes; "Filtered total · net" on /summary. */
   totalLabel: string;
   /** Pre-formatted currency text. */
   totalValue: string;
@@ -29,6 +31,7 @@ type FilteredBannerProps = {
 const FilteredBanner = ({
   descriptors,
   counts,
+  title = "Filtered view",
   totalLabel,
   totalValue,
   tone,
@@ -41,7 +44,7 @@ const FilteredBanner = ({
         <Icon icon={filterIcon} />
       </span>
       <div className="filtered-banner__headline">
-        <span className="filtered-banner__title">Filtered view</span>
+        <span className="filtered-banner__title">{title}</span>
         <span className="filtered-banner__count" aria-live="polite">
           {`${counts.shown} of ${counts.total} entries`}
         </span>

--- a/src/components/common/ExpensesManager/EntryListControls/ListSectionHeader.tsx
+++ b/src/components/common/ExpensesManager/EntryListControls/ListSectionHeader.tsx
@@ -4,16 +4,28 @@ import "./styles.scss";
 type ListSectionHeaderProps = {
   /** "Expenses" / "Incomes", or "Matching expenses" / ... while filtered. */
   label: string;
-  count: number;
+  count?: number;
+  /** Pre-formatted per-list money total — shown instead of the count on /summary. */
+  totalText?: string;
   tone: "expense" | "income";
 };
 
-/** Uppercase tinted label above the entry rows + right-aligned entry count. */
-const ListSectionHeader = ({ label, count, tone }: ListSectionHeaderProps) => (
+/**
+ * Uppercase tinted label above the entry rows + right-aligned detail: the
+ * entry count on the single lists, the per-list money total on /summary.
+ */
+const ListSectionHeader = ({
+  label,
+  count,
+  totalText,
+  tone,
+}: ListSectionHeaderProps) => (
   <div className={`list-section-header list-section-header--${tone}`}>
     <span className="list-section-header__label">{label}</span>
     <span className="list-section-header__count">
-      {`${count} ${count === 1 ? "entry" : "entries"}`}
+      {totalText !== undefined
+        ? totalText
+        : `${count} ${count === 1 ? "entry" : "entries"}`}
     </span>
   </div>
 );

--- a/src/components/common/ExpensesManager/Summaries/Summary/index.js
+++ b/src/components/common/ExpensesManager/Summaries/Summary/index.js
@@ -8,18 +8,35 @@ import {
   formatNumberForDisplay,
   getCategoryPercentagesFromEntries,
   getDatedEntries,
+  getEntryCategoryOption,
   getSumFromEntries,
 } from "../../../../../helpers/entriesHelper/entriesHelper";
+import {
+  filterEntries,
+  getActiveFilterDescriptors,
+  getDefaultEntryFilters,
+  sortEntries,
+} from "../../../../../helpers/entriesHelper/filterSortHelper";
 import { getMonthNameDisplay } from "../../../../../helpers/date";
 import "./styles.scss";
 import SummaryChart from "./components/SummaryChart";
 import SummaryWithChart from "../../../SummaryWithChart";
+import EntryListToolbar from "../../EntryListControls/EntryListToolbar";
+import FilterSheet from "../../EntryListControls/FilterSheet";
+import FilteredBanner from "../../EntryListControls/FilteredBanner";
+import ListSectionHeader from "../../EntryListControls/ListSectionHeader";
+import FilterEmptyState from "../../EntryListControls/FilterEmptyState";
 import {
   ENTRY_TYPES_PLURAL,
   ENTRY_TYPES_SINGULAR,
 } from "../../../../../constants";
 import ChartContainerRowWrapper from "../../../ChartContainerRowWrapper";
 import { withRouter } from "react-router-dom";
+import { connect } from "react-redux";
+import {
+  clearEntryFilters,
+  setEntryFilters,
+} from "../../../../../redux/expensesManager/actionCreators";
 import { Button, Col, Container, Row } from "react-bootstrap";
 
 /**
@@ -31,14 +48,33 @@ import { Button, Col, Container, Row } from "react-bootstrap";
  */
 class Summary extends Component {
   // Everything displayed is derived from props at render time (only the
-  // entry-type filter is state), so the screen also works when entries arrive
-  // after mount — e.g. on a page refresh directly on /summary.
+  // entry-type filter and the sheet visibility are state), so the screen also
+  // works when entries arrive after mount — e.g. on a page refresh directly
+  // on /summary.
   constructor(props) {
     super(props);
     this.state = {
       filter: "",
+      isFilterSheetOpen: false,
     };
   }
+
+  // Owned here so focus can return to the toolbar's Filters button when the
+  // sheet closes (a11y requirement from the design brief).
+  filtersButtonRef = React.createRef();
+
+  openFilterSheet = () => this.setState({ isFilterSheetOpen: true });
+
+  closeFilterSheet = () => {
+    this.setState({ isFilterSheetOpen: false });
+    this.filtersButtonRef.current?.focus();
+  };
+
+  // Dropping a chip resets just that filter back to its default value.
+  handleRemoveFilter = (filterKey) => {
+    const defaults = getDefaultEntryFilters();
+    this.props.onFiltersChange({ [filterKey]: defaults[filterKey] });
+  };
 
   handleChange = (event) => {
     const { value } = event.currentTarget;
@@ -52,6 +88,30 @@ class Summary extends Component {
       month: this.props.selectedDate.month,
     });
 
+  // The ONE shared entryFilters state applied independently to each list —
+  // both lists always narrow and sort together.
+  getFilteredDatedEntries = (datedEntries) => {
+    const { entryFilters } = this.props;
+    const applyFiltersAndSort = (entriesOfType) =>
+      sortEntries(
+        filterEntries({
+          entries: entriesOfType || [],
+          search: entryFilters.search,
+          searchScope: entryFilters.searchScope,
+          category: entryFilters.category,
+        }),
+        entryFilters.sortKey
+      );
+    return {
+      [ENTRY_TYPES_PLURAL.INCOMES]: applyFiltersAndSort(
+        datedEntries?.[ENTRY_TYPES_PLURAL.INCOMES]
+      ),
+      [ENTRY_TYPES_PLURAL.EXPENSES]: applyFiltersAndSort(
+        datedEntries?.[ENTRY_TYPES_PLURAL.EXPENSES]
+      ),
+    };
+  };
+
   getEntriesToSum = (datedEntries) => {
     const { filter } = this.state;
     return (
@@ -62,8 +122,34 @@ class Summary extends Component {
     );
   };
 
-  getFilteredEntries = (datedEntries) => {
+  // While the shared filters are active each list gets a "Matching …" section
+  // header with its per-list total; otherwise the built-in headers stay.
+  getFilteredEntries = (datedEntries, isFiltered) => {
     const { filter } = this.state;
+    const listHeaders = {
+      incomes: isFiltered ? (
+        <ListSectionHeader
+          label="Matching incomes"
+          tone={ENTRY_TYPES_SINGULAR.INCOME}
+          totalText={formatNumberForDisplay(
+            getSumFromEntries({
+              entries: datedEntries?.[ENTRY_TYPES_PLURAL.INCOMES] || [],
+            })
+          )}
+        />
+      ) : undefined,
+      expenses: isFiltered ? (
+        <ListSectionHeader
+          label="Matching expenses"
+          tone={ENTRY_TYPES_SINGULAR.EXPENSE}
+          totalText={formatNumberForDisplay(
+            getSumFromEntries({
+              entries: datedEntries?.[ENTRY_TYPES_PLURAL.EXPENSES] || [],
+            })
+          )}
+        />
+      ) : undefined,
+    };
     const entriesSummary = {
       incomes: !!filter ? (
         <SummaryWithChart
@@ -71,13 +157,18 @@ class Summary extends Component {
           name={capitalize(ENTRY_TYPES_PLURAL.INCOMES)}
           showChart={!!filter}
           entryType={ENTRY_TYPES_SINGULAR.INCOME}
+          listHeader={listHeaders.incomes}
         />
       ) : (
-        <EntriesSummary
-          entries={datedEntries?.[ENTRY_TYPES_PLURAL.INCOMES]}
-          name={ENTRY_TYPES_PLURAL.INCOMES}
-          entryType={ENTRY_TYPES_SINGULAR.INCOME}
-        />
+        <React.Fragment>
+          {listHeaders.incomes}
+          <EntriesSummary
+            entries={datedEntries?.[ENTRY_TYPES_PLURAL.INCOMES]}
+            name={ENTRY_TYPES_PLURAL.INCOMES}
+            entryType={ENTRY_TYPES_SINGULAR.INCOME}
+            hideHeader={isFiltered}
+          />
+        </React.Fragment>
       ),
       expenses: !!filter ? (
         <SummaryWithChart
@@ -85,13 +176,18 @@ class Summary extends Component {
           name={capitalize(ENTRY_TYPES_PLURAL.EXPENSES)}
           showChart={!!filter}
           entryType={ENTRY_TYPES_SINGULAR.EXPENSE}
+          listHeader={listHeaders.expenses}
         />
       ) : (
-        <EntriesSummary
-          entries={datedEntries?.[ENTRY_TYPES_PLURAL.EXPENSES]}
-          name={capitalize(ENTRY_TYPES_PLURAL.EXPENSES)}
-          entryType={ENTRY_TYPES_SINGULAR.EXPENSE}
-        />
+        <React.Fragment>
+          {listHeaders.expenses}
+          <EntriesSummary
+            entries={datedEntries?.[ENTRY_TYPES_PLURAL.EXPENSES]}
+            name={capitalize(ENTRY_TYPES_PLURAL.EXPENSES)}
+            entryType={ENTRY_TYPES_SINGULAR.EXPENSE}
+            hideHeader={isFiltered}
+          />
+        </React.Fragment>
       ),
     };
 
@@ -144,12 +240,29 @@ class Summary extends Component {
   handleCancel = () => this.goBack();
 
   render() {
-    // Derive the month's entries once per render; every figure below shares it.
+    const { entryFilters } = this.props;
+    // Derive the month's entries once per render; every figure below shares
+    // the filtered/sorted view of them.
     const datedEntries = this.getDatedEntries();
-    const chartProps = this.getChartProps(datedEntries);
-    const selectedEntries = this.getFilteredEntries(datedEntries);
+    const filteredDatedEntries = this.getFilteredDatedEntries(datedEntries);
+    const descriptors = getActiveFilterDescriptors({ entryFilters });
+    const isFiltered = descriptors.length > 0;
+    const activeFilterCount = descriptors.filter(
+      (descriptor) => descriptor.key !== "search"
+    ).length;
+    const shownCount =
+      filteredDatedEntries[ENTRY_TYPES_PLURAL.INCOMES].length +
+      filteredDatedEntries[ENTRY_TYPES_PLURAL.EXPENSES].length;
+    const totalCount =
+      (datedEntries?.[ENTRY_TYPES_PLURAL.INCOMES] || []).length +
+      (datedEntries?.[ENTRY_TYPES_PLURAL.EXPENSES] || []).length;
+    const chartProps = this.getChartProps(filteredDatedEntries);
+    const selectedEntries = this.getFilteredEntries(
+      filteredDatedEntries,
+      isFiltered
+    );
     const totalSum = getSumFromEntries({
-      entries: this.getEntriesToSum(datedEntries),
+      entries: this.getEntriesToSum(filteredDatedEntries),
     });
     const selectedEntriesSum = formatNumberForDisplay(totalSum);
     // A zero total stays neutral — green would misread as "money in".
@@ -159,17 +272,75 @@ class Summary extends Component {
         : totalSum > 0
           ? "tile-tone--income"
           : "";
+    // Net filtered total across BOTH lists (regardless of the "Show" select):
+    // filtered incomes minus filtered expenses, signed, green/rose by sign.
+    const netSum = getSumFromEntries({
+      entries: [
+        ...filteredDatedEntries[ENTRY_TYPES_PLURAL.INCOMES],
+        ...filteredDatedEntries[ENTRY_TYPES_PLURAL.EXPENSES],
+      ],
+    });
+    const netDisplayValue =
+      netSum > 0
+        ? `+${formatNumberForDisplay(netSum)}`
+        : formatNumberForDisplay(netSum);
+    const netTone =
+      netSum > 0
+        ? ENTRY_TYPES_SINGULAR.INCOME
+        : netSum < 0
+          ? ENTRY_TYPES_SINGULAR.EXPENSE
+          : "net";
+    // One filter drives both lists, so the category picker offers both kinds.
+    const categoryOptions = [
+      ...getEntryCategoryOption(ENTRY_TYPES_SINGULAR.INCOME),
+      ...getEntryCategoryOption(
+        ENTRY_TYPES_SINGULAR.EXPENSE,
+        this.props.buckets,
+        this.props.unbudgetedCategories
+      ),
+    ];
     return (
       <MainContentContainer
         className="summary-container"
         pageTitle="Monthly Summary"
       >
         <Container fluid className="top-content">
-          <ContentTileSection title="Summary" className={toneClass}>
-            {/** TODO: Make sure the totalization is done here */}
-            {`${capitalize(getMonthNameDisplay(this.props.selectedDate.month))} total: ${selectedEntriesSum}`}
-          </ContentTileSection>
+          {isFiltered ? (
+            <FilteredBanner
+              title="Filtered view · both lists"
+              descriptors={descriptors}
+              counts={{ shown: shownCount, total: totalCount }}
+              totalLabel="Filtered total · net"
+              totalValue={netDisplayValue}
+              tone={netTone}
+              onRemoveFilter={this.handleRemoveFilter}
+              onClearAll={this.props.onClearFilters}
+            />
+          ) : (
+            <ContentTileSection title="Summary" className={toneClass}>
+              {/** TODO: Make sure the totalization is done here */}
+              {`${capitalize(getMonthNameDisplay(this.props.selectedDate.month))} total: ${selectedEntriesSum}`}
+            </ContentTileSection>
+          )}
           {/* TODO: Add the selectedDate display here for letting the user know which year and month he is looking or working at */}
+          <EntryListToolbar
+            entryFilters={entryFilters}
+            activeFilterCount={activeFilterCount}
+            isFilterSheetOpen={this.state.isFilterSheetOpen}
+            onFiltersChange={this.props.onFiltersChange}
+            onOpenFilters={this.openFilterSheet}
+            filtersButtonRef={this.filtersButtonRef}
+          />
+          <FilterSheet
+            isOpen={this.state.isFilterSheetOpen}
+            resultCount={shownCount}
+            entryFilters={entryFilters}
+            categoryOptions={categoryOptions}
+            name="entries"
+            onFiltersChange={this.props.onFiltersChange}
+            onClearAll={this.props.onClearFilters}
+            onClose={this.closeFilterSheet}
+          />
           <label className="form-label" htmlFor="summary-entry-type">
             Show
           </label>
@@ -188,12 +359,18 @@ class Summary extends Component {
               {capitalize(ENTRY_TYPES_PLURAL.EXPENSES)}
             </option>
           </FormSelect>
-          {!this.state.filter && (
-            <ChartContainerRowWrapper>
-              <SummaryChart {...chartProps} />
-            </ChartContainerRowWrapper>
+          {isFiltered && shownCount === 0 ? (
+            <FilterEmptyState onClearAll={this.props.onClearFilters} />
+          ) : (
+            <React.Fragment>
+              {!this.state.filter && (
+                <ChartContainerRowWrapper>
+                  <SummaryChart {...chartProps} />
+                </ChartContainerRowWrapper>
+              )}
+              {selectedEntries}
+            </React.Fragment>
           )}
-          {selectedEntries}
         </Container>
         <Container className="bottom-content" fluid>
           <Row>
@@ -213,4 +390,18 @@ class Summary extends Component {
   }
 }
 
-export default withRouter(Summary);
+const mapStateToProps = (state) => ({
+  entryFilters: state.expensesManager.entryFilters,
+  buckets: state.expensesManager.buckets,
+  unbudgetedCategories: state.expensesManager.unbudgetedCategories,
+});
+
+const mapActionsToProps = (dispatch) => ({
+  onFiltersChange: (partialFilters) => dispatch(setEntryFilters(partialFilters)),
+  onClearFilters: () => dispatch(clearEntryFilters()),
+});
+
+export default connect(
+  mapStateToProps,
+  mapActionsToProps
+)(withRouter(Summary));

--- a/src/integrationTests/summaryFilters.test.tsx
+++ b/src/integrationTests/summaryFilters.test.tsx
@@ -1,0 +1,310 @@
+import { screen } from "@testing-library/react";
+import { renderApp } from "./helpers/renderApp";
+import { seedEntries, ts, MAY } from "./helpers/seed";
+import { openFilterSheet } from "./helpers/filters";
+
+const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.useFakeTimers();
+  jest.setSystemTime(PINNED_DATE);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// Two incomes + three expenses in May with distinct descriptions, categories,
+// amounts and days so both-list narrowing, net polarity and sorting are each
+// observable on screen.
+const seedMayMonth = () =>
+  seedEntries([
+    { date: ts(2026, MAY, 20), amount: "1000", type: "income",  categories_path: ",salary,",         description: "Monthly paycheck" },
+    { date: ts(2026, MAY, 6),  amount: "300",  type: "income",  categories_path: ",deposit,",        description: "Gift money" },
+    { date: ts(2026, MAY, 10), amount: "12.5", type: "expense", categories_path: ",food,",           description: "Coffee beans" },
+    { date: ts(2026, MAY, 2),  amount: "15",   type: "expense", categories_path: ",fun activities,", description: "Gift wrap" },
+    { date: ts(2026, MAY, 1),  amount: "800",  type: "expense", categories_path: ",house (rent),",   description: "Rent paid" },
+  ]);
+
+const ROW_TEXT =
+  /monthly paycheck|gift money|coffee beans|gift wrap|rent paid/i;
+
+const getVisibleRowOrder = () =>
+  screen.getAllByText(ROW_TEXT).map((row) => row.textContent);
+
+type User = Awaited<ReturnType<typeof renderApp>>["user"];
+
+// Navigating from "/" (instead of rendering /summary directly) mirrors the
+// real user flow and the existing /summary suites.
+const goToSummary = async (user: User) => {
+  await user.click(await screen.findByTitle("Summary"));
+  await screen.findAllByText(ROW_TEXT);
+};
+
+const getToolbarSearch = () =>
+  screen.findByRole("textbox", { name: "Search entries" });
+
+// The Show select is also a combobox on /summary, so the category picker is
+// disambiguated by its accessible name instead of the shared helper.
+const pickCategoryInSheet = async (user: User, categoryName: string) => {
+  await user.click(
+    await screen.findByRole("combobox", { name: "Filter by category" })
+  );
+  await user.click(await screen.findByRole("option", { name: categoryName }));
+};
+
+describe("/summary - one shared filter drives both lists", () => {
+  it("narrows incomes AND expenses from a single search term", async () => {
+    seedMayMonth();
+    const { user } = await renderApp("/");
+    await goToSummary(user);
+
+    await user.type(await getToolbarSearch(), "gift");
+
+    expect(await screen.findByText(/gift money/i)).toBeInTheDocument();
+    expect(screen.getByText(/gift wrap/i)).toBeInTheDocument();
+    expect(screen.queryByText(/monthly paycheck/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/coffee beans/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/rent paid/i)).not.toBeInTheDocument();
+  });
+
+  it("applies the shared sort to both lists at once", async () => {
+    seedMayMonth();
+    const { user } = await renderApp("/");
+    await goToSummary(user);
+
+    // Default: each list date-descending, incomes first.
+    expect(getVisibleRowOrder()).toEqual([
+      "Salary - Monthly paycheck",
+      "Deposit - Gift money",
+      "Food - Coffee beans",
+      "Fun activities - Gift wrap",
+      "House (rent) - Rent paid",
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "Sort entries" }));
+    await user.click(
+      await screen.findByRole("menuitemradio", { name: /amount — highest first/i })
+    );
+
+    expect(getVisibleRowOrder()).toEqual([
+      "Salary - Monthly paycheck",
+      "Deposit - Gift money",
+      "House (rent) - Rent paid",
+      "Fun activities - Gift wrap",
+      "Food - Coffee beans",
+    ]);
+  });
+
+  it("supports income categories in the sheet's category picker", async () => {
+    seedMayMonth();
+    const { user } = await renderApp("/");
+    await goToSummary(user);
+
+    await openFilterSheet(user);
+    await pickCategoryInSheet(user, "Deposit");
+    await user.click(screen.getByRole("button", { name: "Show 1 result" }));
+
+    expect(screen.getByText(/gift money/i)).toBeInTheDocument();
+    expect(screen.queryByText(/monthly paycheck/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/rent paid/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Category: Deposit")).toBeInTheDocument();
+    expect(screen.getByText("1 of 5 entries")).toBeInTheDocument();
+  });
+});
+
+describe("/summary - filtered banner with net total", () => {
+  it('replaces the month tile with "Filtered view · both lists" and a signed positive net', async () => {
+    seedMayMonth();
+    const { user } = await renderApp("/");
+    await goToSummary(user);
+
+    // Unfiltered: the month tile shows the plain total.
+    expect(screen.getByText(/may total:/i)).toBeInTheDocument();
+
+    // "gift" matches one income (300) and one expense (15): net +285.
+    await user.type(await getToolbarSearch(), "gift");
+
+    expect(
+      await screen.findByText("Filtered view · both lists")
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/may total:/i)).not.toBeInTheDocument();
+    expect(screen.getByText("2 of 5 entries")).toBeInTheDocument();
+    expect(screen.getByText("Filtered total · net")).toBeInTheDocument();
+    expect(screen.getByText("+$285.00")).toBeInTheDocument();
+    expect(screen.getByText('"gift"')).toBeInTheDocument();
+  });
+
+  it("shows a negative net in the rose tone when filtered expenses outweigh incomes", async () => {
+    seedMayMonth();
+    const { user } = await renderApp("/");
+    await goToSummary(user);
+
+    // "coffee" matches only the $12.50 expense: net -12.50. The same text
+    // also appears as the Matching-expenses per-list total, so the banner
+    // value is picked out of the matches by its class.
+    await user.type(await getToolbarSearch(), "coffee");
+
+    expect((await screen.findAllByText("-$12.50")).length).toBeGreaterThan(0);
+    expect(screen.getByText("1 of 5 entries")).toBeInTheDocument();
+    // Tone comes from the sign: rose for negative, green for positive.
+    const negativeNet = screen
+      .getAllByText("-$12.50")
+      .find((element) =>
+        element.classList.contains("filtered-banner__total-value")
+      );
+    expect(negativeNet).toHaveClass("filtered-banner__total-value--expense");
+
+    await user.clear(await getToolbarSearch());
+    await user.type(await getToolbarSearch(), "gift");
+    expect(await screen.findByText("+$285.00")).toHaveClass(
+      "filtered-banner__total-value--income"
+    );
+  });
+
+  it("shows per-list Matching headers with per-list totals while filtered", async () => {
+    seedMayMonth();
+    const { user } = await renderApp("/");
+    await goToSummary(user);
+
+    await user.type(await getToolbarSearch(), "gift");
+
+    expect(await screen.findByText("Matching incomes")).toBeInTheDocument();
+    expect(screen.getByText("Matching expenses")).toBeInTheDocument();
+    // Per-list totals live inside each header ($300.00 also shows as the row
+    // amount, so the assertions are scoped to the headers' total slot).
+    expect(
+      screen.getByText("$300.00", { selector: ".list-section-header__count" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("-$15.00", { selector: ".list-section-header__count" })
+    ).toBeInTheDocument();
+  });
+
+  it("drops a single chip and Clear restores the month tile and default sort", async () => {
+    seedMayMonth();
+    const { user } = await renderApp("/");
+    await goToSummary(user);
+
+    await user.click(screen.getByRole("button", { name: "Sort entries" }));
+    await user.click(
+      await screen.findByRole("menuitemradio", { name: /amount — highest first/i })
+    );
+    await user.type(await getToolbarSearch(), "gift");
+
+    // Dropping the search chip empties the search but keeps the sort.
+    await user.click(
+      screen.getByRole("button", { name: 'Remove filter "gift"' })
+    );
+    expect(await getToolbarSearch()).toHaveValue("");
+    expect(
+      screen.getByRole("button", { name: "Sort entries" })
+    ).toHaveTextContent("Sort: Amount");
+
+    // Clear from the banner resets everything, including the sort.
+    await user.type(await getToolbarSearch(), "gift");
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(await screen.findByText(/may total:/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText("Filtered view · both lists")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Sort entries" })
+    ).toHaveTextContent("Sort: Date");
+    expect(getVisibleRowOrder()[0]).toBe("Salary - Monthly paycheck");
+  });
+});
+
+describe("/summary - cross-screen filter carryover", () => {
+  it("a filter set on /expenses is already active on /summary", async () => {
+    seedMayMonth();
+    const { user } = await renderApp("/");
+
+    await user.click(await screen.findByText("Expenses"));
+    await screen.findByText(/coffee beans/i);
+    await user.type(await getToolbarSearch(), "coffee");
+    expect(await screen.findByText("Filtered view")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /go back/i }));
+    await goToSummary(user);
+
+    expect(
+      await screen.findByText("Filtered view · both lists")
+    ).toBeInTheDocument();
+    expect(screen.getByText('"coffee"')).toBeInTheDocument();
+    expect(screen.getByText(/coffee beans/i)).toBeInTheDocument();
+    expect(screen.queryByText(/monthly paycheck/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('/summary - "Show" select regression and interplay', () => {
+  it("still switches between All/Incomes/Expenses when no filters are active", async () => {
+    seedMayMonth();
+    const { user } = await renderApp("/");
+    await goToSummary(user);
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Show" }),
+      "Incomes"
+    );
+    expect(await screen.findByText(/monthly paycheck/i)).toBeInTheDocument();
+    expect(screen.queryByText(/rent paid/i)).not.toBeInTheDocument();
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Show" }),
+      "Expenses"
+    );
+    expect(await screen.findByText(/rent paid/i)).toBeInTheDocument();
+    expect(screen.queryByText(/monthly paycheck/i)).not.toBeInTheDocument();
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Show" }),
+      "All incomes and expenses"
+    );
+    expect(await screen.findByText(/monthly paycheck/i)).toBeInTheDocument();
+    expect(screen.getByText(/rent paid/i)).toBeInTheDocument();
+  });
+
+  it("filters apply within whatever the Show select displays", async () => {
+    seedMayMonth();
+    const { user } = await renderApp("/");
+    await goToSummary(user);
+
+    await user.type(await getToolbarSearch(), "gift");
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Show" }),
+      "Expenses"
+    );
+
+    // Only the matching expense is listed, but the banner still reports both
+    // lists (one filter state drives everything).
+    expect(await screen.findByText(/gift wrap/i)).toBeInTheDocument();
+    expect(screen.queryByText(/gift money/i)).not.toBeInTheDocument();
+    expect(screen.getByText("2 of 5 entries")).toBeInTheDocument();
+    expect(screen.getByText("+$285.00")).toBeInTheDocument();
+  });
+});
+
+describe("/summary - empty state", () => {
+  it("shows the dashed card and $0.00 net when nothing matches across both lists", async () => {
+    seedMayMonth();
+    const { user } = await renderApp("/");
+    await goToSummary(user);
+
+    await user.type(await getToolbarSearch(), "zzz nothing");
+
+    expect(
+      await screen.findByText("No entries match your filters")
+    ).toBeInTheDocument();
+    expect(screen.getByText("0 of 5 entries")).toBeInTheDocument();
+    expect(screen.getByText("$0.00")).toBeInTheDocument();
+    expect(screen.queryByText(ROW_TEXT)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Clear all filters" }));
+
+    expect((await screen.findAllByText(ROW_TEXT)).length).toBe(5);
+    expect(screen.getByText(/may total:/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Final PR (3 of 3) for the filters & sorting UX (builds on #131 and #132). On `/summary`:

- The **shared toolbar** (live search, Sort button, Filters button) and the **Filters sheet/panel** now render on the summary screen. `Summary` is Redux-connected (`entryFilters` + `setEntryFilters`/`clearEntryFilters`, same `connect()` pattern as `EntriesSummaryWithFilter`).
- **One filter/sort state drives BOTH lists**: a single search term narrows incomes and expenses simultaneously; the shared sort key orders both lists. Because the state is app-wide, a filter set on `/expenses` or `/incomes` is already active when navigating to `/summary` — and vice versa.
- **Banner variant** — "Filtered view · both lists", combined "N of M entries" across both lists, and **"Filtered total · net"** = filtered incomes − filtered expenses, signed (e.g. `+$3,125.02`), `$income`-green when positive, `$expense`-rose when negative, neutral at zero (matching the existing tile-tone rule).
- **Per-list headers** — "Matching incomes" / "Matching expenses" with per-list money totals while filtered (`ListSectionHeader` gained an optional `totalText` shown instead of the entry count; the single lists keep their counts unchanged).
- **Charts recompute** against the filtered subsets (incomes-vs-expenses doughnut and the per-type category chart), and a **combined empty state** (dashed card, `$0.00` net, "0 of M entries") shows when nothing matches across both lists.
- **"Show" select untouched** per the plan: it still switches All/Incomes/Expenses exactly as before; filters apply within whatever it displays, while the banner keeps reporting both lists. Dashboard (`/`) remains untouched.

## Implementation notes

- `FilteredBanner` gained an optional `title` prop (default "Filtered view") — no behavior change for the single lists.
- The sheet's category picker on `/summary` offers **income AND expense categories** (merged `getEntryCategoryOption` outputs; empty option "All entries") since one filter drives both lists — the plan didn't specify the option set, and this is the only choice consistent with "one shared state".
- Both `/summary` lists now honor the shared sort key even when no filter is active (date-newest-first by default) — same behavior the single lists have had since PR 1; previously `/summary` rendered in raw insertion order.
- `entries`/`selectedDate` keep flowing in from the Dashboard route props; `connect` only adds `entryFilters`, `buckets`, `unbudgetedCategories` and the two action creators.

## Follow-up (unchanged from #131)

Remove the legacy `category` reducer field + `CATEGORY_CHANGE` action, now fully unused.

## Test coverage

- New integration suite `src/integrationTests/summaryFilters.test.tsx` (11 tests, screen-query assertions only): both-list narrowing from one search; shared sort ordering asserted on the full on-screen row order across both lists; income category ("Deposit") picked in the sheet; signed net total with both polarity fixtures (`+$285.00` green class / `-$12.50` rose class); per-list "Matching" headers with per-list totals; chip removal keeping the sort + banner Clear restoring the month tile and Date sort; cross-screen carryover (filter set on `/expenses` via UI is active on `/summary`); "Show" select regression (All/Incomes/Expenses with no filters) and interplay (filters apply within the shown type, banner still combined); combined empty state with a working "Clear all filters".

Gates (all green): `npm test -- --watchAll=false --testPathPattern="integrationTests"` (13 suites / 140 tests), `npm test -- --watchAll=false` (254 passed, 14 pre-existing skips), `npm run typecheck`, `npm run lint` (exit 0, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TFfG9FQKb8LiJjc8gXrNM

---
_Generated by [Claude Code](https://claude.ai/code/session_014TFfG9FQKb8LiJjc8gXrNM)_