### PR TITLE
PR 4 — QA fix round 1: mobile sheet stacking, banner placement/surface, sort icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.1] - 2026-07-20
+
+### Fixed
+- Mobile: the open filter sheet and its scrim now stack above the fixed
+  bottom tab bar (`.app-nav`, z-index 100) — previously the nav painted
+  over the sheet's "Clear all" / "Show N results" buttons and stole their
+  taps, making them unreachable on phones. The sheet's bottom padding also
+  gains `env(safe-area-inset-bottom)` clearance for devices with a home
+  indicator
+- The gold filtered banner now renders BETWEEN the toolbar/filter panel
+  and the matching rows on all three screens (/expenses, /incomes,
+  /summary), matching the approved mock — the toolbar stays on top while
+  filtering; the unfiltered layout (tile above toolbar) is unchanged
+- Banner surface softened to match the mock: border is now
+  gold at 30% alpha (`rgba($accent, 0.3)`) instead of full-strength gold
+  on all sides, and the background is a vertical gold wash
+  (`rgba($accent, 0.10)` → `rgba($accent, 0.04)`) instead of a gradient
+  into a hardcoded surface color; the 3px solid gold left bar is kept
+- The toolbar's Sort button now carries the leading sort-arrows icon from
+  the mock ("⇅ Sort: Date"), mirroring the magnifier and funnel icons on
+  its siblings
+- Narrow phones: slightly trimmed toolbar paddings/gaps and search font
+  size so the "Search entries" placeholder no longer truncates at 390px
+
 ## [1.5.0] - 2026-07-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/src/components/common/ExpensesManager/EntryListControls/EntryListToolbar.tsx
+++ b/src/components/common/ExpensesManager/EntryListControls/EntryListToolbar.tsx
@@ -3,6 +3,7 @@ import { Icon } from "@iconify/react";
 import searchIcon from "@iconify-icons/codicon/search";
 import checkIcon from "@iconify-icons/codicon/check";
 import filterIcon from "@iconify-icons/codicon/filter";
+import sortIcon from "@iconify-icons/codicon/arrow-swap";
 import { EntryFilters, SortKey } from "../../../../helpers/entriesHelper/filterSortHelper";
 import "./styles.scss";
 
@@ -162,6 +163,9 @@ const EntryListToolbar = ({
             isSortMenuOpen ? closeSortMenu() : setIsSortMenuOpen(true)
           }
         >
+          <span className="entry-list-toolbar__sort-icon" aria-hidden="true">
+            <Icon icon={sortIcon} />
+          </span>
           Sort:{" "}
           <strong className="entry-list-toolbar__sort-current">
             {selectedOption.buttonLabel}

--- a/src/components/common/ExpensesManager/EntryListControls/styles.scss
+++ b/src/components/common/ExpensesManager/EntryListControls/styles.scss
@@ -6,7 +6,7 @@
 .entry-list-toolbar {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.5rem;
   margin: $vertical-standard-margin 0;
 
   &__search {
@@ -15,7 +15,7 @@
     display: flex;
     align-items: center;
     height: 2.7rem;
-    padding: 0 0.4rem 0 0.8rem;
+    padding: 0 0.4rem 0 0.7rem;
     background-color: $bg-raised;
     border: 1px solid $border-subtle;
     border-radius: $radius-control;
@@ -35,7 +35,7 @@
     display: flex;
     align-items: center;
     color: $text-secondary;
-    margin-right: 0.5rem;
+    margin-right: 0.4rem;
   }
 
   &__search-input {
@@ -45,6 +45,9 @@
     background: transparent;
     border: none;
     color: $text-primary;
+    // Slightly smaller than body text so the "Search entries" placeholder
+    // fits next to the Sort/Filters buttons on narrow phones.
+    font-size: 0.9rem;
 
     &::placeholder {
       color: $text-secondary;
@@ -71,7 +74,7 @@
     align-items: center;
     gap: 0.3rem;
     height: 2.7rem;
-    padding: 0 0.9rem;
+    padding: 0 0.7rem;
     background-color: $bg-raised;
     border: 1px solid $border-subtle;
     border-radius: $radius-control;
@@ -92,6 +95,12 @@
     &:focus-visible {
       @include focus-ring();
     }
+  }
+
+  &__sort-icon {
+    display: flex;
+    align-items: center;
+    margin-right: 0.1rem;
   }
 
   &__sort-current {
@@ -193,7 +202,7 @@
     align-items: center;
     gap: 0.4rem;
     height: 2.7rem;
-    padding: 0 0.9rem;
+    padding: 0 0.7rem;
     flex: 0 0 auto;
     background-color: $bg-raised;
     border: 1px solid $border-subtle;
@@ -247,11 +256,14 @@
 // Same markup for both; only the presentation switches.
 // ---------------------------------------------------------------------------
 .filter-sheet {
-  // The one literal the design specifies for the scrim.
+  // Scrim + sheet must stack ABOVE the fixed bottom nav (.app-nav,
+  // z-index 100 in Header.scss) or the nav paints over the sheet's action
+  // buttons and steals their taps on mobile.
+  // The rgba(0,0,0,0.5) scrim is the one literal the design specifies.
   &__scrim {
     position: fixed;
     inset: 0;
-    z-index: 30;
+    z-index: 110;
     background-color: rgba(0, 0, 0, 0.5);
   }
 
@@ -260,14 +272,18 @@
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 31;
+    z-index: 111;
     max-height: 85vh;
     overflow-y: auto;
     background-color: $bg-surface;
     border: 1px solid $border-strong;
     border-radius: $radius-shell $radius-shell 0 0;
     box-shadow: $shadow-pop;
-    padding: 0.5rem 1rem 1rem;
+    // Extra bottom clearance so "Clear all" / "Show N results" always sit
+    // above the device home indicator and clear of the nav area.
+    // Interpolated so libsass passes the CSS env() through untouched
+    // (same trick as the min() clamp in CategorySearchSelect).
+    padding: 0.5rem 1rem #{"calc(1rem + env(safe-area-inset-bottom, 0px))"};
   }
 
   &__grabber {
@@ -500,8 +516,10 @@
   position: relative;
   margin: 0 0 $vertical-standard-margin;
   padding: 0.9rem 1rem 0.9rem 1.2rem;
-  background: linear-gradient(135deg, $accent-soft, $bg-raised);
-  border: 1px solid $accent;
+  // Soft gold wash + softened gold border (alpha derived from the $accent
+  // token), per the approved mock; the 3px solid gold left bar stays.
+  background: linear-gradient(180deg, rgba($accent, 0.1), rgba($accent, 0.04));
+  border: 1px solid rgba($accent, 0.3);
   border-radius: $radius-card;
   box-shadow: $shadow-card;
   overflow: hidden;

--- a/src/components/common/ExpensesManager/Summaries/EntriesSummaryWithFilter/index.js
+++ b/src/components/common/ExpensesManager/Summaries/EntriesSummaryWithFilter/index.js
@@ -93,17 +93,7 @@ class EntrySummaryWithFilter extends Component {
         pageTitle="Monthly report"
       >
         <Container className="top-content" fluid>
-          {isFiltered ? (
-            <FilteredBanner
-              descriptors={descriptors}
-              counts={{ shown: visibleEntries.length, total: monthEntries.length }}
-              totalLabel="Filtered total"
-              totalValue={formatNumberForDisplay(totalSum)}
-              tone={this.props.entryType}
-              onRemoveFilter={this.handleRemoveFilter}
-              onClearAll={this.props.onClearFilters}
-            />
-          ) : (
+          {!isFiltered && (
             <ContentTileSection
               title="Summary"
               className={`tile-tone--${this.props.entryType}`}
@@ -130,6 +120,20 @@ class EntrySummaryWithFilter extends Component {
             onClearAll={this.props.onClearFilters}
             onClose={this.closeFilterSheet}
           />
+          {/* Per the approved mock the banner sits BETWEEN the toolbar/panel
+              and the matching rows (the tile it replaces is above the
+              toolbar, but the filtered state keeps the toolbar on top). */}
+          {isFiltered && (
+            <FilteredBanner
+              descriptors={descriptors}
+              counts={{ shown: visibleEntries.length, total: monthEntries.length }}
+              totalLabel="Filtered total"
+              totalValue={formatNumberForDisplay(totalSum)}
+              tone={this.props.entryType}
+              onRemoveFilter={this.handleRemoveFilter}
+              onClearAll={this.props.onClearFilters}
+            />
+          )}
           {isFiltered && visibleEntries.length === 0 ? (
             <FilterEmptyState onClearAll={this.props.onClearFilters} />
           ) : (

--- a/src/components/common/ExpensesManager/Summaries/Summary/index.js
+++ b/src/components/common/ExpensesManager/Summaries/Summary/index.js
@@ -305,18 +305,7 @@ class Summary extends Component {
         pageTitle="Monthly Summary"
       >
         <Container fluid className="top-content">
-          {isFiltered ? (
-            <FilteredBanner
-              title="Filtered view · both lists"
-              descriptors={descriptors}
-              counts={{ shown: shownCount, total: totalCount }}
-              totalLabel="Filtered total · net"
-              totalValue={netDisplayValue}
-              tone={netTone}
-              onRemoveFilter={this.handleRemoveFilter}
-              onClearAll={this.props.onClearFilters}
-            />
-          ) : (
+          {!isFiltered && (
             <ContentTileSection title="Summary" className={toneClass}>
               {/** TODO: Make sure the totalization is done here */}
               {`${capitalize(getMonthNameDisplay(this.props.selectedDate.month))} total: ${selectedEntriesSum}`}
@@ -359,6 +348,20 @@ class Summary extends Component {
               {capitalize(ENTRY_TYPES_PLURAL.EXPENSES)}
             </option>
           </FormSelect>
+          {/* Per the approved mock the banner sits BETWEEN the toolbar/panel
+              and the matching rows; the toolbar stays on top while filtered. */}
+          {isFiltered && (
+            <FilteredBanner
+              title="Filtered view · both lists"
+              descriptors={descriptors}
+              counts={{ shown: shownCount, total: totalCount }}
+              totalLabel="Filtered total · net"
+              totalValue={netDisplayValue}
+              tone={netTone}
+              onRemoveFilter={this.handleRemoveFilter}
+              onClearAll={this.props.onClearFilters}
+            />
+          )}
           {isFiltered && shownCount === 0 ? (
             <FilterEmptyState onClearAll={this.props.onClearFilters} />
           ) : (


### PR DESCRIPTION
## What

QA fix round 1 for the filters & sorting feature (follows #131/#132/#133). Fixes the two blockers and the minor findings from QA's end-to-end browser run (mobile 390px + desktop).

### Blocker 1 — Mobile: bottom nav painted over the open filter sheet
The scrim/panel stacked at z-index 30/31 while the fixed bottom nav (`.app-nav`, `Header.scss`) sits at 100 — the nav covered "Clear all" / "Show N results" and `elementFromPoint` at the button center hit `app-nav__item`, so a real tap navigated away.
**Fix:** scrim/panel raised to **110/111** (the nav's z-index is untouched, per instruction), and the panel's bottom padding gains `calc(1rem + env(safe-area-inset-bottom, 0px))` clearance (interpolated for libsass, mirroring the repo's existing `min()` clamp trick). With the sheet now stacking above the nav, the actions are visible and tappable; QA's Playwright re-run is the authoritative check — jsdom can't assert stacking, so no synthetic z-index test was added and all existing suites stay green.

### Blocker 2 — Banner position vs the approved mock
The gold banner rendered above the toolbar (in the old tile's slot); mock frames 4–8 show toolbar → (open panel) → banner → matching rows.
**Fix:** on all three screens (`/expenses`, `/incomes`, `/summary`) the banner now renders **between the toolbar/panel and the rows**; the toolbar stays on top while filtered. Unfiltered order is unchanged (tile → toolbar → rows). No test pinned the old DOM order — all assertions were already UI-semantic and pass unchanged.

### Minor 3 — Banner surface
Border softened to `rgba($accent, 0.3)` (token-derived alpha), background changed to the mock's vertical gold wash `linear-gradient(180deg, rgba($accent, 0.10), rgba($accent, 0.04))` — the gradient into the raised-surface color (the `#1e252f` QA saw in computed CSS) is gone. The 3px solid gold left bar is kept as-is.

### Minor 4 — Sort button icon
Leading sort-arrows icon (codicon `arrow-swap`) added to the Sort button ("⇅ Sort: Date"), same aria-hidden span treatment as the magnifier and funnel icons.

### Optional — 390px placeholder truncation
Trimmed toolbar gap (0.6→0.5rem), Sort/Filters button padding (0.9→0.7rem) and set the search input to 0.9rem so "Search entries" fits without layout changes.

## QA findings addressed / accepted (orchestrator rulings)

- **Kept:** signed filtered totals (e.g. `-$29.40`) — consistent with the app's existing "Expenses total: -$…" convention.
- **Kept:** the Filters badge counts filters **beyond search** only, per the design brief.
- **Out of scope:** typography changes; chart animation/palette.

## Verification

SCSS output validated by compiling `EntryListControls/styles.scss` standalone (z-indexes 110/111, env() clearance, and token-derived rgba values all present in the emitted CSS).

Gates (all green): `npm test -- --watchAll=false --testPathPattern="integrationTests"` (13 suites / 140 tests), `npm test -- --watchAll=false` (254 passed, 14 pre-existing skips), `npm run typecheck`, `npm run lint` (exit 0, 0 errors).

Version bumped to **1.5.1** (patch) in `package.json` + `package-lock.json`, with CHANGELOG "Fixed" entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TFfG9FQKb8LiJjc8gXrNM

---
_Generated by [Claude Code](https://claude.ai/code/session_014TFfG9FQKb8LiJjc8gXrNM)_