### PR TITLE
Visual refresh v1: category icons, two-line rows, total tile, nav & brand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.0] - 2026-07-21
+
+### Added
+- Visual refresh: category-aware entry icons. Each entry row's chip now shows a
+  glyph keyed to the entry's category (home, car, cart, coffee, briefcase, …)
+  instead of a bare up/down arrow; the chip's income-green / expense-rose tint
+  still carries direction. Custom (user-created) categories fall back to the
+  arrow, so nothing ever renders a broken chip. Backed by a single dependency-
+  free 2px-stroke glyph set (`GlyphIcon`) and a `categoryIcons` map covering
+  every seed category, with a unit test asserting each resolves and unknowns
+  fall back
+- Visual refresh: two-line entry rows. An entry *with* a description now shows
+  its category as a semibold title over the description as muted subtext; an
+  entry *without* one keeps the single line. The rule is content-driven, so
+  rows never reshape on resize
+- Visual refresh: a two-tier monthly total tile on /summary, /expenses and
+  /incomes — a muted label with a large, tone-colored value on a softly tinted
+  card (expense-rose / income-green, neutral at zero), replacing the flat
+  `label: amount` string
+- Visual refresh: tabular figures for money columns via a shared
+  `money-figures` mixin, so right-aligned amounts, totals, the balance hero and
+  bucket numbers line up in a grid instead of drifting row to row
+- Visual refresh: navigation destinations now use their own glyphs (grid for
+  Categories, a bucket for Buckets) and the active tab's indicator is a compact
+  soft-gold lozenge behind the icon (at the app's control radius) rather than a
+  full-width tint
+- Visual refresh: a whisper-faint gold page glow — one fixed radial wash
+  anchored to the top of the page, under every surface layer so it never
+  touches content contrast (new `$glow-page` token)
+- Visual refresh: the brand mark is now a single SVG source (`BrandMark` /
+  `public/logo.svg`) rendered as the header lockup and served as a vector
+  favicon, keeping the gold-over-slate double-bar motif on the app's rounded-
+  square shape. The raster `logo192/512.png` and `favicon.ico` stay as
+  fallbacks pending brand sign-off before regenerating them from the source
+
+### Changed
+- Visual refresh: the month navigator's Prev/Next steppers are now rounded
+  squares (matching the app's control shape; circles stay reserved for the
+  money chips) and, at the first/last month with data, the stepper stays in
+  place disabled instead of vanishing — so the control never teleports under
+  the thumb and screen readers announce it rather than dropping it silently
+
 ## [1.5.1] - 2026-07-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" sizes="any" />
+    <!-- Vector favicon (candidate 3): the single SVG source scales crisply in
+         browser tabs; the .ico above stays as a fallback for older browsers. -->
+    <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Expenses Tracker">
+  <rect x="1.5" y="1.5" width="45" height="45" rx="11" fill="#161b22" stroke="#f0b90b" stroke-width="1.6"/>
+  <path d="M8.5 19.6 17.6 15l21.9 7.9-9.1 4.6z" fill="#f0b90b"/>
+  <path d="M8.5 28.6 17.6 24l21.9 7.9-9.1 4.6z" fill="#6b7686"/>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,6 +8,12 @@
       "type": "image/x-icon"
     },
     {
+      "src": "logo.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "any"
+    },
+    {
       "src": "logo192.png",
       "type": "image/png",
       "sizes": "192x192"

--- a/src/components/Dashboard/components/DashboardContent/styles.scss
+++ b/src/components/Dashboard/components/DashboardContent/styles.scss
@@ -19,6 +19,7 @@
     }
 
     .balance-hero__amount {
+      @include money-figures();
       font-size: 2rem;
       font-weight: 700;
       letter-spacing: -0.02em;

--- a/src/components/common/BrandMark/index.tsx
+++ b/src/components/common/BrandMark/index.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+/**
+ * The app's brand mark, redrawn from the original raster logo as a single
+ * vector source (candidate 3 of the visual refresh). It keeps the gold-over-
+ * slate double-bar motif — ledger lines / an upward glance — but moves the
+ * container from a circle to the app's rounded-square shape language, and
+ * stays crisp at every density. This one component is the source the header
+ * lockup renders from; `public/logo.svg` mirrors it for the favicon / PWA
+ * icons.
+ */
+type BrandMarkProps = {
+  size?: number;
+  className?: string;
+  title?: string;
+};
+
+const BrandMark = ({ size = 40, className, title }: BrandMarkProps) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox="0 0 48 48"
+    role="img"
+    aria-label={title ?? "Expenses Tracker"}
+  >
+    <rect
+      x="1.5"
+      y="1.5"
+      width="45"
+      height="45"
+      rx="11"
+      fill="#161b22"
+      stroke="#f0b90b"
+      strokeWidth="1.6"
+    />
+    <path d="M8.5 19.6 17.6 15l21.9 7.9-9.1 4.6z" fill="#f0b90b" />
+    <path d="M8.5 28.6 17.6 24l21.9 7.9-9.1 4.6z" fill="#6b7686" />
+  </svg>
+);
+
+export default BrandMark;

--- a/src/components/common/ContentTitleSection.js
+++ b/src/components/common/ContentTitleSection.js
@@ -5,36 +5,67 @@ import chevronRight from "@iconify-icons/codicon/chevron-right";
 import RowLink from "./RowLink";
 import "./ContentTitleSelection.scss";
 
-const RowContent = ({ isLink, children }) => (
-  <Col xs={12} className="tile-inner">
-    <span className="tile-content">{children}</span>
-    {isLink && (
-      <Icon icon={chevronRight} className="tile-chevron" aria-hidden="true" />
-    )}
-  </Col>
-);
+const RowContent = ({ isLink, children, label, value }) => {
+  // Two-tier money tile (candidate 8): a muted label and a large, tone-colored
+  // value, so the number is read first and its caption second — instead of one
+  // undifferentiated colored line.
+  const isTotal = label !== undefined && value !== undefined;
+  return (
+    <Col xs={12} className={`tile-inner${isTotal ? " tile-inner--total" : ""}`}>
+      {isTotal ? (
+        <React.Fragment>
+          <span className="tile-total__label">{label}</span>
+          <span className="tile-total__value">{value}</span>
+        </React.Fragment>
+      ) : (
+        <span className="tile-content">{children}</span>
+      )}
+      {isLink && (
+        <Icon icon={chevronRight} className="tile-chevron" aria-hidden="true" />
+      )}
+    </Col>
+  );
+};
 
 /**
  * A card-shaped section tile. With `to` it becomes a tappable link (chevron
  * affordance included); without it, it is a static heading card. The `title`
  * becomes the HTML title attribute (some tests locate tiles by it).
+ *
+ * Passing `label` + `value` renders the two-tier "total" variant (muted label
+ * left, prominent tone-colored value right, on a softly tinted card); the tone
+ * comes from a `tile-tone--income` / `tile-tone--expense` className, and a
+ * neutral (zero) total keeps the default surface.
  */
-const ContentTileSection = ({ title = "", to, className = "", children }) => (
-  <React.Fragment>
-    {to ? (
-      <RowLink
-        title={title}
-        to={to}
-        className={`content-title-selection ${className}`}
-      >
-        <RowContent isLink>{children}</RowContent>
-      </RowLink>
-    ) : (
-      <Row title={title} className={`content-title-selection ${className}`}>
-        <RowContent>{children}</RowContent>
-      </Row>
-    )}
-  </React.Fragment>
-);
+const ContentTileSection = ({
+  title = "",
+  to,
+  className = "",
+  label,
+  value,
+  children,
+}) => {
+  const isTotal = label !== undefined && value !== undefined;
+  const composedClassName = `content-title-selection${
+    isTotal ? " content-title-selection--total" : ""
+  } ${className}`.trim();
+  return (
+    <React.Fragment>
+      {to ? (
+        <RowLink title={title} to={to} className={composedClassName}>
+          <RowContent isLink label={label} value={value}>
+            {children}
+          </RowContent>
+        </RowLink>
+      ) : (
+        <Row title={title} className={composedClassName}>
+          <RowContent label={label} value={value}>
+            {children}
+          </RowContent>
+        </Row>
+      )}
+    </React.Fragment>
+  );
+};
 
 export default ContentTileSection;

--- a/src/components/common/ContentTitleSelection.scss
+++ b/src/components/common/ContentTitleSelection.scss
@@ -50,3 +50,50 @@ a.content-title-selection {
 .content-title-selection.tile-tone--expense .tile-content {
   color: $expense;
 }
+
+// Two-tier total tile (candidate 8): label/value hierarchy on a soft-tinted
+// card. The largest number on these screens finally gets the weight it deserves.
+.content-title-selection--total {
+  .tile-inner--total {
+    align-items: baseline;
+  }
+
+  .tile-total__label {
+    color: $text-secondary;
+    font-size: 0.85rem;
+    font-weight: 600;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .tile-total__value {
+    @include money-figures();
+    flex: 0 0 auto;
+    font-size: 1.4rem;
+    font-weight: 700;
+    line-height: 1.2;
+    color: $text-primary;
+    white-space: nowrap;
+  }
+
+  // Sign drives the tint; a zero/net total keeps the neutral surface + value.
+  &.tile-tone--expense {
+    background-color: $expense-soft;
+    border-color: rgba($expense, 0.28);
+
+    .tile-total__value {
+      color: $expense;
+    }
+  }
+
+  &.tile-tone--income {
+    background-color: $income-soft;
+    border-color: rgba($income, 0.28);
+
+    .tile-total__value {
+      color: $income;
+    }
+  }
+}

--- a/src/components/common/ExpensesManager/Buckets/components/Bucket/styles.scss
+++ b/src/components/common/ExpensesManager/Buckets/components/Bucket/styles.scss
@@ -21,6 +21,7 @@ $bucket-danger: $chart-expense;
     }
 
     .usage-percentage {
+      @include money-figures();
       text-align: right;
       font-weight: 700;
       font-size: 0.9rem;
@@ -77,6 +78,7 @@ $bucket-danger: $chart-expense;
   }
 
   .bucket-figures {
+    @include money-figures();
     margin-top: 0.45rem;
     font-size: 0.88rem;
     color: $text-secondary;

--- a/src/components/common/ExpensesManager/Summaries/EntriesSummary.js
+++ b/src/components/common/ExpensesManager/Summaries/EntriesSummary.js
@@ -2,14 +2,23 @@ import { capitalize } from "lodash";
 import React from "react";
 import { Col, Container, Row } from "react-bootstrap";
 import { formatNumberForDisplay } from "../../../../helpers/entriesHelper/entriesHelper";
+import { getCategoryGlyph } from "../../../../helpers/entriesHelper/categoryIcons";
 import { IconMoneyIn, IconMoneyOut } from "../../Icons";
+import GlyphIcon from "../../GlyphIcon";
 import "./EntriesSummary.scss";
 import RowLink from "../../RowLink";
 
 function GetEntriesList({ entries, entryType }) {
-  const Icon = entryType === "income" ? IconMoneyIn : IconMoneyOut;
+  // Fallback glyph for categories with no icon mapping (user-created ones):
+  // the money-direction arrow — i.e. exactly today's chip.
+  const FallbackIcon = entryType === "income" ? IconMoneyIn : IconMoneyOut;
   return entries.map((entry, key) => {
     const category = entry.categories_path.split(",")[1];
+    // Category drives the glyph; chip tint keeps carrying direction (candidate 1).
+    const glyph = getCategoryGlyph(category);
+    // Described rows stack (category title + note); bare rows keep one line
+    // (candidate 4) — the rule is content-driven, so rows never reshape on resize.
+    const hasDescription = Boolean(entry.description);
     return (
       <RowLink
         to={`edit-${entryType}/${entry.id}`}
@@ -21,12 +30,23 @@ function GetEntriesList({ entries, entryType }) {
         */}
         <Col xs={1} className="item-icon">
           <span className="item-icon-chip" aria-hidden="true">
-            <Icon />
+            {glyph ? <GlyphIcon name={glyph} size={15} /> : <FallbackIcon />}
           </span>
         </Col>
-        <Col xs={7} className="item-description">
-          {capitalize(category)}
-          {entry.description ? ` - ${entry.description}` : ``}
+        <Col
+          xs={7}
+          className={`item-description${
+            hasDescription ? " item-description--stacked" : ""
+          }`}
+        >
+          {hasDescription ? (
+            <React.Fragment>
+              <span className="item-category">{capitalize(category)}</span>
+              <span className="item-note">{entry.description}</span>
+            </React.Fragment>
+          ) : (
+            capitalize(category)
+          )}
         </Col>
         <Col xs={4} className="item-amount">
           {formatNumberForDisplay(entry.amount)}

--- a/src/components/common/ExpensesManager/Summaries/EntriesSummary.scss
+++ b/src/components/common/ExpensesManager/Summaries/EntriesSummary.scss
@@ -19,6 +19,7 @@
 
     .item-total {
       @include adjust-text-in-vertical-axis();
+      @include money-figures();
       justify-content: flex-end;
       font-weight: 600;
     }
@@ -66,8 +67,36 @@
       min-width: 0;
     }
 
+    // Described rows (candidate 4): category becomes a semibold title and the
+    // note a muted line below it, each with its own ellipsis. Bare rows keep
+    // the single-line `.item-description` above.
+    .item-description--stacked {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      white-space: normal;
+      line-height: 1.35;
+
+      .item-category {
+        font-size: 0.92rem;
+        font-weight: 600;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .item-note {
+        font-size: 0.78rem;
+        color: $text-muted;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+
     .item-amount {
       @include adjust-text-in-vertical-axis();
+      @include money-figures();
       justify-content: flex-end;
       font-weight: 600;
       flex: 0 0 auto;

--- a/src/components/common/ExpensesManager/Summaries/EntriesSummaryWithFilter/index.js
+++ b/src/components/common/ExpensesManager/Summaries/EntriesSummaryWithFilter/index.js
@@ -97,9 +97,9 @@ class EntrySummaryWithFilter extends Component {
             <ContentTileSection
               title="Summary"
               className={`tile-tone--${this.props.entryType}`}
-            >
-              {`${capitalize(entryTypePlural)} total: ${formatNumberForDisplay(totalSum)}`}
-            </ContentTileSection>
+              label={`${capitalize(entryTypePlural)} total`}
+              value={formatNumberForDisplay(totalSum)}
+            />
           )}
           {/* TODO: Add the selectedDate display here for letting the user know which year and month he is looking or working at */}
           <EntryListToolbar

--- a/src/components/common/ExpensesManager/Summaries/Summary/index.js
+++ b/src/components/common/ExpensesManager/Summaries/Summary/index.js
@@ -306,10 +306,12 @@ class Summary extends Component {
       >
         <Container fluid className="top-content">
           {!isFiltered && (
-            <ContentTileSection title="Summary" className={toneClass}>
-              {/** TODO: Make sure the totalization is done here */}
-              {`${capitalize(getMonthNameDisplay(this.props.selectedDate.month))} total: ${selectedEntriesSum}`}
-            </ContentTileSection>
+            <ContentTileSection
+              title="Summary"
+              className={toneClass}
+              label={`${capitalize(getMonthNameDisplay(this.props.selectedDate.month))} total`}
+              value={selectedEntriesSum}
+            />
           )}
           {/* TODO: Add the selectedDate display here for letting the user know which year and month he is looking or working at */}
           <EntryListToolbar

--- a/src/components/common/GlyphIcon/index.tsx
+++ b/src/components/common/GlyphIcon/index.tsx
@@ -1,0 +1,265 @@
+import React from "react";
+
+/**
+ * A single-source, dependency-free glyph set drawn in one 2px-stroke family
+ * (viewBox 0 0 24 24) to match the codicon chevrons already used in the header.
+ * It backs both the category chips on entry rows (candidate 1) and the main
+ * navigation destinations (candidate 7), so the ledger and the nav speak one
+ * visual language.
+ *
+ * Stroke defaults live on the <svg> element and inherit down; individual marks
+ * override only where they must (e.g. a filled dot).
+ */
+export type GlyphName =
+  | "home"
+  | "car"
+  | "bus"
+  | "cart"
+  | "coffee"
+  | "wine"
+  | "zap"
+  | "wifi"
+  | "phone"
+  | "repeat"
+  | "bank"
+  | "shirt"
+  | "gift"
+  | "ticket"
+  | "plane"
+  | "dumbbell"
+  | "sparkle"
+  | "alert"
+  | "user"
+  | "book"
+  | "health"
+  | "bottle"
+  | "briefcase"
+  | "deposit"
+  | "vault"
+  | "grid"
+  | "bucket"
+  | "database";
+
+const GLYPHS: Record<GlyphName, React.ReactNode> = {
+  home: (
+    <>
+      <path d="M3 10.5 12 3l9 7.5" />
+      <path d="M5 9.7V21h5v-6h4v6h5V9.7" />
+    </>
+  ),
+  car: (
+    <>
+      <path d="M5.5 11l1.1-3.8A2 2 0 0 1 8.5 5.8h7a2 2 0 0 1 1.9 1.4L18.5 11" />
+      <rect x="3" y="11" width="18" height="6" rx="1.6" />
+      <circle cx="7.3" cy="17.6" r="1.4" />
+      <circle cx="16.7" cy="17.6" r="1.4" />
+    </>
+  ),
+  bus: (
+    <>
+      <rect x="4.5" y="3.5" width="15" height="14" rx="2" />
+      <path d="M4.5 10h15" />
+      <path d="M8.5 14h.01M15.5 14h.01" />
+      <path d="M7.5 17.5v2.5M16.5 17.5v2.5" />
+    </>
+  ),
+  cart: (
+    <>
+      <circle cx="9" cy="21" r="1" />
+      <circle cx="20" cy="21" r="1" />
+      <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" />
+    </>
+  ),
+  coffee: (
+    <>
+      <path d="M18 8h1a4 4 0 0 1 0 8h-1" />
+      <path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4z" />
+      <line x1="6" y1="1.5" x2="6" y2="4" />
+      <line x1="10" y1="1.5" x2="10" y2="4" />
+      <line x1="14" y1="1.5" x2="14" y2="4" />
+    </>
+  ),
+  wine: (
+    <>
+      <path d="M8 3h8l-.6 6.2a3.4 3.4 0 0 1-6.8 0z" />
+      <path d="M12 12.8V19" />
+      <path d="M8.5 21h7" />
+    </>
+  ),
+  zap: (
+    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+  ),
+  wifi: (
+    <>
+      <path d="M2.8 9.8a14.5 14.5 0 0 1 18.4 0" />
+      <path d="M5.8 13.2a10 10 0 0 1 12.4 0" />
+      <path d="M8.8 16.5a5.5 5.5 0 0 1 6.4 0" />
+      <circle cx="12" cy="19.6" r="0.4" fill="currentColor" />
+    </>
+  ),
+  phone: (
+    <>
+      <rect x="7" y="2.5" width="10" height="19" rx="2.2" />
+      <path d="M11 18.3h2" />
+    </>
+  ),
+  repeat: (
+    <>
+      <polyline points="17 1.5 21 5.5 17 9.5" />
+      <path d="M3 11.5v-2a4 4 0 0 1 4-4h14" />
+      <polyline points="7 22.5 3 18.5 7 14.5" />
+      <path d="M21 12.5v2a4 4 0 0 1-4 4H3" />
+    </>
+  ),
+  bank: (
+    <>
+      <path d="M3.5 9.5 12 4l8.5 5.5" />
+      <line x1="4.5" y1="9.5" x2="19.5" y2="9.5" />
+      <line x1="6.5" y1="13" x2="6.5" y2="17.5" />
+      <line x1="10.3" y1="13" x2="10.3" y2="17.5" />
+      <line x1="13.7" y1="13" x2="13.7" y2="17.5" />
+      <line x1="17.5" y1="13" x2="17.5" y2="17.5" />
+      <line x1="3.5" y1="21" x2="20.5" y2="21" />
+    </>
+  ),
+  shirt: (
+    <path d="M9.2 3.5 12 5.2l2.8-1.7 5 3.2-1.8 3-2-1.1V20.5H8V8.6l-2 1.1-1.8-3z" />
+  ),
+  gift: (
+    <>
+      <polyline points="20 12 20 22 4 22 4 12" />
+      <rect x="2" y="7" width="20" height="5" />
+      <line x1="12" y1="22" x2="12" y2="7" />
+      <path d="M12 7H7.5a2.5 2.5 0 0 1 0-5C11 2 12 7 12 7z" />
+      <path d="M12 7h4.5a2.5 2.5 0 0 0 0-5C13 2 12 7 12 7z" />
+    </>
+  ),
+  ticket: (
+    <>
+      <path d="M2 9.5a2.8 2.8 0 0 0 0 5V19h20v-4.5a2.8 2.8 0 0 1 0-5V5H2z" />
+      <path d="M14 5v2.4M14 10.8v2.4M14 16.6V19" />
+    </>
+  ),
+  plane: (
+    <>
+      <path d="M21.5 2.5 11 13" />
+      <path d="M21.5 2.5 14.8 21.5l-3.8-8.5-8.5-3.8z" />
+    </>
+  ),
+  dumbbell: (
+    <>
+      <path d="M6.7 6.7v10.6M17.3 6.7v10.6" />
+      <path d="M3.5 9.5v5M20.5 9.5v5" />
+      <path d="M6.7 12h10.6" />
+    </>
+  ),
+  sparkle: (
+    <>
+      <path d="M11 4l1.6 4.6L17.2 10l-4.6 1.6L11 16l-1.6-4.4L4.8 10l4.6-1.4z" />
+      <path d="M18.5 14.5l.8 2.2 2.2.8-2.2.8-.8 2.2-.8-2.2-2.2-.8 2.2-.8z" />
+    </>
+  ),
+  alert: (
+    <>
+      <path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </>
+  ),
+  user: (
+    <>
+      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+      <circle cx="12" cy="7" r="4" />
+    </>
+  ),
+  book: (
+    <>
+      <path d="M2 4h6a4 4 0 0 1 4 4v13a3 3 0 0 0-3-3H2z" />
+      <path d="M22 4h-6a4 4 0 0 0-4 4v13a3 3 0 0 1 3-3h7z" />
+    </>
+  ),
+  health: (
+    <>
+      <path d="M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.6l-1-1a5.5 5.5 0 0 0-7.8 7.8l8.8 8.8 8.8-8.8a5.5 5.5 0 0 0 0-7.8z" />
+      <polyline points="7.5 12 10 12 11.5 9.8 13 13.6 14.5 12 16.5 12" />
+    </>
+  ),
+  bottle: (
+    <>
+      <path d="M9 8.5h6V19a2 2 0 0 1-2 2h-2a2 2 0 0 1-2-2z" />
+      <path d="M10 8.5V7a2 2 0 0 1 4 0v1.5" />
+      <path d="M12 2.8V5" />
+      <path d="M9 12.3h6M9 15.3h6" />
+    </>
+  ),
+  briefcase: (
+    <>
+      <rect x="2.5" y="7" width="19" height="13.5" rx="2" />
+      <path d="M16 20.5V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v15.5" />
+    </>
+  ),
+  deposit: (
+    <>
+      <path d="M12 3v9" />
+      <polyline points="8.5 8.5 12 12 15.5 8.5" />
+      <path d="M3 13.5v4a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3v-4" />
+    </>
+  ),
+  vault: (
+    <>
+      <rect x="3" y="3.5" width="18" height="15.5" rx="2" />
+      <circle cx="12" cy="11.2" r="3.4" />
+      <path d="M12 7.8V6.5M12 16v-1.4M8.6 11.2H7.3M16.7 11.2h-1.3" />
+      <path d="M6 19v2M18 19v2" />
+    </>
+  ),
+  grid: (
+    <>
+      <rect x="3.5" y="3.5" width="7" height="7" rx="1.6" />
+      <rect x="13.5" y="3.5" width="7" height="7" rx="1.6" />
+      <rect x="3.5" y="13.5" width="7" height="7" rx="1.6" />
+      <rect x="13.5" y="13.5" width="7" height="7" rx="1.6" />
+    </>
+  ),
+  bucket: (
+    <>
+      <path d="M4.2 7.5h15.6l-1.4 11.8a2 2 0 0 1-2 1.7H7.6a2 2 0 0 1-2-1.7z" />
+      <path d="M3.2 7.5a8.8 3 0 0 1 17.6 0" />
+      <path d="M5.7 13.4h12.6" />
+    </>
+  ),
+  database: (
+    <>
+      <ellipse cx="12" cy="5.5" rx="7.5" ry="3" />
+      <path d="M4.5 5.5v6c0 1.66 3.36 3 7.5 3s7.5-1.34 7.5-3v-6" />
+      <path d="M4.5 11.5v6c0 1.66 3.36 3 7.5 3s7.5-1.34 7.5-3v-6" />
+    </>
+  ),
+};
+
+type GlyphIconProps = {
+  name: GlyphName;
+  size?: number;
+  className?: string;
+};
+
+const GlyphIcon = ({ name, size = 20, className }: GlyphIconProps) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    {GLYPHS[name]}
+  </svg>
+);
+
+export default GlyphIcon;
+export { GLYPHS };

--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -1,12 +1,7 @@
 import React from "react";
 import { Link, NavLink } from "react-router-dom";
-import { Icon } from "@iconify/react";
-import homeIcon from "@iconify-icons/codicon/home";
-import tagIcon from "@iconify-icons/codicon/tag";
-import pieChartIcon from "@iconify-icons/codicon/pie-chart";
-import syncIcon from "@iconify-icons/codicon/sync";
-import databaseIcon from "@iconify-icons/codicon/database";
-import logoImage from "../../images/expenses_tracker_logo.png";
+import GlyphIcon from "./GlyphIcon";
+import BrandMark from "./BrandMark";
 /**
  * TODO:
  * Reinstate the log-out action
@@ -19,16 +14,19 @@ import "./Header.scss";
 const isHomeActive = (match, location) =>
   location.pathname === "/" || location.pathname.startsWith("/dashboard");
 
+// Destination-specific glyphs (candidate 7): the shape says what the tab is.
+// `grid` for Categories and a `bucket` for Buckets (a spending-limit container,
+// the feature's own metaphor) read truer than the old tag/pie-chart icons.
 const NAV_ITEMS = [
-  { to: "/", label: "Home", icon: homeIcon, isActive: isHomeActive },
-  { to: "/categories", label: "Categories", icon: tagIcon },
-  { to: "/buckets", label: "Buckets", icon: pieChartIcon },
-  { to: "/fixed-entries", label: "Fixed Entries", icon: syncIcon },
+  { to: "/", label: "Home", icon: "home", isActive: isHomeActive },
+  { to: "/categories", label: "Categories", icon: "grid" },
+  { to: "/buckets", label: "Buckets", icon: "bucket" },
+  { to: "/fixed-entries", label: "Fixed Entries", icon: "repeat" },
   {
     to: "/data-management",
     label: "Data",
     ariaLabel: "Data Management",
-    icon: databaseIcon,
+    icon: "database",
   },
 ];
 
@@ -41,7 +39,7 @@ const Header = () => (
   <header className="app-header">
     <div className="app-header__bar">
       <Link to="/" className="app-header__brand">
-        <img src={logoImage} alt="Expenses tracker logo" className="logo" />
+        <BrandMark size={40} className="logo" title="Expenses Tracker logo" />
         <span className="app-header__name">Expenses Tracker</span>
       </Link>
       <nav className="app-nav" aria-label="Main navigation">
@@ -55,7 +53,12 @@ const Header = () => (
             activeClassName="app-nav__item--active"
             aria-label={ariaLabel}
           >
-            <Icon icon={icon} className="app-nav__icon" aria-hidden="true" />
+            {/* The active indicator sits behind the icon only (candidate 7),
+                so "you are here" reads at a glance without tinting the whole
+                tab. */}
+            <span className="app-nav__glyph">
+              <GlyphIcon name={icon} size={20} className="app-nav__icon" />
+            </span>
             <span className="app-nav__label">{label}</span>
           </NavLink>
         ))}

--- a/src/components/common/Header.scss
+++ b/src/components/common/Header.scss
@@ -23,7 +23,8 @@
     }
 
     .logo {
-      height: 44px;
+      width: 40px;
+      height: 40px;
       display: block;
     }
   }
@@ -56,16 +57,33 @@
     border-radius: $radius-control;
     padding: 0.35rem 0.5rem;
     min-width: 3.6rem;
-    transition: color $transition-quick, background-color $transition-quick;
+    transition: color $transition-quick;
 
     &:hover {
       color: $text-primary;
-      background-color: $bg-raised-hover;
+
+      .app-nav__glyph {
+        background-color: $bg-raised-hover;
+      }
     }
 
     &:focus-visible {
       @include focus-ring();
     }
+  }
+
+  // The active indicator lives here — a soft-gold lozenge behind the icon only,
+  // at $radius-control (the app's control radius), not a 999px pill.
+  .app-nav__glyph {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.4rem;
+    height: 1.55rem;
+    border: 1px solid transparent;
+    border-radius: $radius-control;
+    transition: background-color $transition-quick, border-color $transition-quick,
+      box-shadow $transition-quick;
   }
 
   .app-nav__icon {
@@ -79,11 +97,19 @@
 
   .app-nav__item--active {
     color: $accent;
-    background-color: $accent-soft;
+
+    .app-nav__glyph {
+      background-color: $accent-soft;
+      border-color: rgba($accent, 0.28);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    }
 
     &:hover {
       color: $accent-hover;
-      background-color: $accent-soft;
+
+      .app-nav__glyph {
+        background-color: $accent-soft;
+      }
     }
   }
 }

--- a/src/components/common/NavigableMonthHeader/NavigavleMonthHeader.tsx
+++ b/src/components/common/NavigableMonthHeader/NavigavleMonthHeader.tsx
@@ -28,35 +28,38 @@ const NavigableMonthHeader = ({
       dateAdjacencyType,
     });
 
+  // At the first/last month with data the stepper stays put but goes disabled,
+  // instead of vanishing (candidate 2) — the control never teleports under the
+  // thumb, and screen readers announce it as disabled rather than silently
+  // dropping it.
+  const canGoPrev = canGo("prev");
+  const canGoNext = canGo("next");
+
   return (
     <div className="month-header">
-      {canGo("prev") ? (
-        <button
-          type="button"
-          className="month-header__step"
-          aria-label="Previous month"
-          onClick={() => go("prev")}
-        >
-          <Icon icon={chevronLeft} aria-hidden="true" />
-        </button>
-      ) : (
-        <span className="month-header__step month-header__step--placeholder" />
-      )}
+      <button
+        type="button"
+        className="month-header__step"
+        aria-label="Previous month"
+        onClick={() => go("prev")}
+        disabled={!canGoPrev}
+        aria-disabled={!canGoPrev}
+      >
+        <Icon icon={chevronLeft} aria-hidden="true" />
+      </button>
       <ScreenTitle
         screenTitle={`${getMonthNameDisplay(selectedDate.month)} ${selectedDate.year}`}
       />
-      {canGo("next") ? (
-        <button
-          type="button"
-          className="month-header__step"
-          aria-label="Next month"
-          onClick={() => go("next")}
-        >
-          <Icon icon={chevronRight} aria-hidden="true" />
-        </button>
-      ) : (
-        <span className="month-header__step month-header__step--placeholder" />
-      )}
+      <button
+        type="button"
+        className="month-header__step"
+        aria-label="Next month"
+        onClick={() => go("next")}
+        disabled={!canGoNext}
+        aria-disabled={!canGoNext}
+      >
+        <Icon icon={chevronRight} aria-hidden="true" />
+      </button>
     </div>
   );
 };

--- a/src/components/common/NavigableMonthHeader/styles.scss
+++ b/src/components/common/NavigableMonthHeader/styles.scss
@@ -25,7 +25,9 @@
     color: $text-primary;
     background-color: $bg-raised;
     border: 1px solid $border-subtle;
-    border-radius: 50%;
+    // Rounded square joins the app's control shape language (buttons, inputs,
+    // nav pills); circles stay reserved for the entry-row money chips.
+    border-radius: $radius-control;
     cursor: pointer;
     transition: background-color $transition-quick, border-color $transition-quick;
 
@@ -37,10 +39,17 @@
     &:focus-visible {
       @include focus-ring();
     }
-  }
 
-  .month-header__step--placeholder {
-    visibility: hidden;
-    pointer-events: none;
+    // Data edge: control stays in place, dimmed and non-interactive.
+    &:disabled,
+    &[aria-disabled="true"] {
+      opacity: 0.35;
+      cursor: default;
+
+      &:hover {
+        background-color: $bg-raised;
+        border-color: $border-subtle;
+      }
+    }
   }
 }

--- a/src/components/common/NoSessionContainer.js
+++ b/src/components/common/NoSessionContainer.js
@@ -1,14 +1,14 @@
 import React from "react";
 import { Col, Container, Row } from "react-bootstrap";
 import "./NoSessionContainer.scss";
-import logoImage from "../../images/expenses_tracker_logo.png";
+import BrandMark from "./BrandMark";
 
 function NoSessionContainer({ children }) {
   return (
     <Container>
       <Row className="NoSessionContainer">
         <Col className="upperSide">
-          <img src={logoImage} alt="Expenses tracker logo" className="logo" />
+          <BrandMark size={96} className="logo" title="Expenses Tracker logo" />
         </Col>
         <Col>{children}</Col>
       </Row>

--- a/src/global.scss
+++ b/src/global.scss
@@ -123,7 +123,9 @@ input[type="number"].form-control {
 // -----------------------------------------------------------------------------
 #root {
   color: $text-primary;
-  background-color: $bg-page;
+  // Transparent so the fixed page glow painted on `body` (index.scss) shows
+  // through; `body` still carries the solid $bg-page base beneath it.
+  background-color: transparent;
 
   a {
     color: $text-primary;

--- a/src/helpers/entriesHelper/categoryIcons.test.ts
+++ b/src/helpers/entriesHelper/categoryIcons.test.ts
@@ -1,0 +1,29 @@
+import { getCategoryGlyph } from "./categoryIcons";
+import { EXPENSE_CATEGORIES, INCOME_CATEGORIES } from "./entriesHelper";
+import { GLYPHS } from "../../components/common/GlyphIcon";
+
+const SEED_CATEGORIES = [...INCOME_CATEGORIES, ...EXPENSE_CATEGORIES];
+
+describe("category → icon map", () => {
+  it("resolves every seed category to a glyph that exists in the set", () => {
+    SEED_CATEGORIES.forEach((category) => {
+      const glyph = getCategoryGlyph(category);
+      expect(glyph).not.toBeNull();
+      // The resolved name must be a real glyph, not a dangling key.
+      expect(Object.prototype.hasOwnProperty.call(GLYPHS, glyph as string)).toBe(
+        true
+      );
+    });
+  });
+
+  it("is case-insensitive, matching the bucket-name normalization", () => {
+    expect(getCategoryGlyph("EATING OUT")).toBe(getCategoryGlyph("eating out"));
+    expect(getCategoryGlyph("  Food  ")).toBe(getCategoryGlyph("food"));
+  });
+
+  it("falls back to null for unknown / user-created categories", () => {
+    expect(getCategoryGlyph("Totally custom category")).toBeNull();
+    expect(getCategoryGlyph("")).toBeNull();
+    expect(getCategoryGlyph(undefined)).toBeNull();
+  });
+});

--- a/src/helpers/entriesHelper/categoryIcons.ts
+++ b/src/helpers/entriesHelper/categoryIcons.ts
@@ -1,0 +1,64 @@
+import type { GlyphName } from "../../components/common/GlyphIcon";
+
+/**
+ * Maps a category to the glyph shown inside its entry-row chip (candidate 1 of
+ * the visual refresh). Keyed by the lowercased category name — the same
+ * normalization buckets already use — so a lookup is case-insensitive.
+ *
+ * The map covers every seed category from `entriesHelper.js`
+ * (INCOME_CATEGORIES + EXPENSE_CATEGORIES). Any category not listed here —
+ * i.e. one the user created themselves — resolves to `null`, and the caller
+ * falls back to today's money-direction arrow, so custom categories degrade to
+ * exactly the current behavior rather than a broken chip.
+ */
+const CATEGORY_ICON_MAP: Record<string, GlyphName> = {
+  // Home
+  "house (rent)": "home",
+  "house stuff": "home",
+  "insurance house": "home",
+  // Car / transport
+  car: "car",
+  "car parking": "car",
+  "car insurance": "car",
+  gas: "car",
+  "car expenses": "car",
+  transportation: "bus",
+  // Food & drink
+  food: "cart",
+  "eating out": "coffee",
+  alcohol: "wine",
+  // Utilities & services
+  hydro: "zap",
+  internet: "wifi",
+  "mobile phone plan": "phone",
+  subscriptions: "repeat",
+  "bank fees": "bank",
+  laundry: "shirt",
+  // Life
+  donation: "gift",
+  "fun activities": "ticket",
+  travel: "plane",
+  sports: "dumbbell",
+  beauty: "sparkle",
+  unexpected: "alert",
+  "person 1 bucket": "user",
+  "person 2 bucket": "user",
+  education: "book",
+  health: "health",
+  "baby stuff": "bottle",
+  // Income
+  salary: "briefcase",
+  deposit: "deposit",
+  saving: "vault",
+};
+
+/**
+ * Returns the glyph name for a category, or `null` when the category has no
+ * mapping (custom user categories) so the caller can fall back to the arrow.
+ */
+export const getCategoryGlyph = (category?: string): GlyphName | null => {
+  if (!category) return null;
+  return CATEGORY_ICON_MAP[category.trim().toLowerCase()] ?? null;
+};
+
+export { CATEGORY_ICON_MAP };

--- a/src/index.scss
+++ b/src/index.scss
@@ -13,8 +13,14 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  // Match the app background so overscroll areas don't flash white.
+  // Match the app background so overscroll areas don't flash white. A whisper-
+  // faint gold wash (candidate 5) is anchored to the top of the column on top
+  // of it; painted at a fixed size so it never stretches or repaints on scroll,
+  // and it sits under every surface layer so it touches no content contrast.
   background-color: $bg-page;
+  background-image: $glow-page;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
   // Tabular figures keep amounts vertically aligned in lists.
   font-feature-settings: "tnum";
 }

--- a/src/integrationTests/filterSheet.test.tsx
+++ b/src/integrationTests/filterSheet.test.tsx
@@ -26,6 +26,8 @@ const seedMayExpenses = () =>
 
 const ROW_TEXT = /coffee beans|morning latte|bus pass|rent paid/i;
 
+// Rows render the description on its own line (candidate 4); matching the note
+// span yields the descriptions in the exact vertical order the user sees.
 const getVisibleRowOrder = () =>
   screen.getAllByText(ROW_TEXT).map((row) => row.textContent);
 
@@ -111,7 +113,7 @@ describe("filter sheet - opening and shared state", () => {
     expect(
       screen.getByRole("button", { name: "Sort entries" })
     ).toHaveTextContent("Sort: Amount");
-    expect(getVisibleRowOrder()[0]).toBe("House (rent) - Rent paid");
+    expect(getVisibleRowOrder()[0]).toBe("Rent paid");
   });
 
   it("clears every filter with Clear all (sheet stays open, count restored)", async () => {
@@ -176,12 +178,12 @@ describe("filtered banner", () => {
     const { user } = await renderApp("/");
     await goToExpenses(user);
 
-    expect(screen.getByText(/expenses total:/i)).toBeInTheDocument();
+    expect(screen.getByText(/expenses total/i)).toBeInTheDocument();
 
     await user.type(await getToolbarSearch(), "coffee");
 
     expect(await screen.findByText("Filtered view")).toBeInTheDocument();
-    expect(screen.queryByText(/expenses total:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/expenses total/i)).not.toBeInTheDocument();
     expect(screen.getByText("1 of 4 entries")).toBeInTheDocument();
     expect(screen.getByText('"coffee"')).toBeInTheDocument();
     expect(screen.getByText("Filtered total")).toBeInTheDocument();
@@ -229,16 +231,16 @@ describe("filtered banner", () => {
     await user.click(screen.getByRole("button", { name: "Clear" }));
 
     expect(screen.queryByText("Filtered view")).not.toBeInTheDocument();
-    expect(await screen.findByText(/expenses total:/i)).toBeInTheDocument();
+    expect(await screen.findByText(/expenses total/i)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Sort entries" })
     ).toHaveTextContent("Sort: Date");
     // Order is back to date, newest first.
     expect(getVisibleRowOrder()).toEqual([
-      "Food - Coffee beans",
-      "Eating out - Morning latte",
-      "Transportation - Bus pass",
-      "House (rent) - Rent paid",
+      "Coffee beans",
+      "Morning latte",
+      "Bus pass",
+      "Rent paid",
     ]);
   });
 });
@@ -307,7 +309,7 @@ describe("empty state", () => {
       screen.queryByText("No entries match your filters")
     ).not.toBeInTheDocument();
     expect((await screen.findAllByText(ROW_TEXT)).length).toBe(4);
-    expect(screen.getByText(/expenses total:/i)).toBeInTheDocument();
+    expect(screen.getByText(/expenses total/i)).toBeInTheDocument();
   });
 });
 

--- a/src/integrationTests/filterSortEntries.test.tsx
+++ b/src/integrationTests/filterSortEntries.test.tsx
@@ -29,8 +29,8 @@ const seedMayExpenses = () =>
 
 const ROW_TEXT = /coffee beans|morning latte|bus pass|rent paid/i;
 
-// Rows render as "Category - Description" in document order, so this is the
-// exact vertical order the user sees.
+// Rows render the description on its own line (candidate 4); matching the note
+// span yields the descriptions in the exact vertical order the user sees.
 const getVisibleRowOrder = () =>
   screen.getAllByText(ROW_TEXT).map((row) => row.textContent);
 
@@ -99,10 +99,10 @@ describe("/expenses - sort menu", () => {
 
     expect(getSortButton()).toHaveTextContent("Sort: Date");
     expect(getVisibleRowOrder()).toEqual([
-      "Food - Coffee beans",
-      "Eating out - Morning latte",
-      "Transportation - Bus pass",
-      "House (rent) - Rent paid",
+      "Coffee beans",
+      "Morning latte",
+      "Bus pass",
+      "Rent paid",
     ]);
   });
 
@@ -118,10 +118,10 @@ describe("/expenses - sort menu", () => {
 
     expect(getSortButton()).toHaveTextContent("Sort: Amount");
     expect(getVisibleRowOrder()).toEqual([
-      "House (rent) - Rent paid",
-      "Transportation - Bus pass",
-      "Eating out - Morning latte",
-      "Food - Coffee beans",
+      "Rent paid",
+      "Bus pass",
+      "Morning latte",
+      "Coffee beans",
     ]);
   });
 
@@ -136,11 +136,13 @@ describe("/expenses - sort menu", () => {
     );
 
     expect(getSortButton()).toHaveTextContent("Sort: Name");
+    // Sorted by category name (Eating out, Food, House (rent), Transportation);
+    // the notes below reflect that category order.
     expect(getVisibleRowOrder()).toEqual([
-      "Eating out - Morning latte",
-      "Food - Coffee beans",
-      "House (rent) - Rent paid",
-      "Transportation - Bus pass",
+      "Morning latte",
+      "Coffee beans",
+      "Rent paid",
+      "Bus pass",
     ]);
   });
 
@@ -158,7 +160,7 @@ describe("/expenses - sort menu", () => {
 
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     expect(getSortButton()).toHaveTextContent("Sort: Amount");
-    expect(getVisibleRowOrder()[0]).toBe("House (rent) - Rent paid");
+    expect(getVisibleRowOrder()[0]).toBe("Rent paid");
   });
 
   it("closes on Escape without changing the sort", async () => {
@@ -316,11 +318,9 @@ describe("/incomes - toolbar behaves symmetrically", () => {
     );
 
     expect(
-      screen.getAllByText(/paycheck|tax refund|piggy bank/i).map((row) => row.textContent)
-    ).toEqual([
-      "Deposit - Tax refund",
-      "Salary - Paycheck",
-      "Saving - Piggy bank",
-    ]);
+      screen
+        .getAllByText(/paycheck|tax refund|piggy bank/i)
+        .map((row) => row.textContent)
+    ).toEqual(["Tax refund", "Paycheck", "Piggy bank"]);
   });
 });

--- a/src/integrationTests/fixedEntries.test.tsx
+++ b/src/integrationTests/fixedEntries.test.tsx
@@ -96,13 +96,13 @@ describe("toggle routing — recurring vs regular entries", () => {
 
     // The expense must be visible in the regular expenses view.
     await user.click(screen.getByRole("link", { name: /^Expenses \$/ }));
-    expect(await screen.findByText(/Food - One-off/)).toBeInTheDocument();
+    expect(await screen.findByText(/One-off/)).toBeInTheDocument();
 
     // It must NOT appear on the Fixed Entries page.
     await user.click(screen.getByRole("link", { name: /fixed entries/i }));
     await screen.findByText("March 2026");
     await waitFor(() =>
-      expect(screen.queryByText(/Food - One-off/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/One-off/)).not.toBeInTheDocument()
     );
   });
 
@@ -119,12 +119,12 @@ describe("toggle routing — recurring vs regular entries", () => {
     // Fixed entries are materialised into the entries tree, so the entry must
     // appear in the regular expenses view as well as the Fixed Entries page.
     await user.click(screen.getByRole("link", { name: /^Expenses \$/ }));
-    expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
+    expect(await screen.findByText(/Groceries/)).toBeInTheDocument();
 
     // It must also appear on the dedicated Fixed Entries page.
     await user.click(screen.getByRole("link", { name: /fixed entries/i }));
     await screen.findByText("March 2026");
-    expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
+    expect(await screen.findByText(/Groceries/)).toBeInTheDocument();
     // $150.00 appears twice: the entry's own amount and the section total
     // (only one fixed expense this month, so the total equals it).
     expect(screen.getAllByText("$150.00")).toHaveLength(2);
@@ -146,7 +146,7 @@ describe("toggle routing — recurring vs regular entries", () => {
     // The Fixed Entries page must also list the new recurring entry.
     await user.click(screen.getByRole("link", { name: /fixed entries/i }));
     await screen.findByText("March 2026");
-    expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
+    expect(await screen.findByText(/Groceries/)).toBeInTheDocument();
   });
 });
 
@@ -157,18 +157,18 @@ describe("fixed entries without any prior regular entries", () => {
   });
 
   it("adds and displays a fixed expense for the current month", async () => {
-    // With no prior entries, only May 2026 (pinned today) is in the tree —
-    // no Prev / Next navigation buttons should be visible.
+    // With no prior entries, only May 2026 (pinned today) is in the tree — the
+    // Prev / Next steppers stay in place but are disabled rather than removed.
     const { user } = await renderApp("/");
     await screen.findByText("May 2026");
-    expect(screen.queryByRole("button", { name: /prev/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /prev/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
 
     await addRecurringExpense(user, { amount: "100", description: "Groceries" });
 
     await user.click(screen.getByRole("link", { name: /fixed entries/i }));
     await screen.findByText("May 2026");
-    expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
+    expect(await screen.findByText(/Groceries/)).toBeInTheDocument();
     // $100.00 appears twice: the entry's own amount and the section total.
     expect(screen.getAllByText("$100.00")).toHaveLength(2);
   });
@@ -230,7 +230,7 @@ describe("toggling recurring ON in the edit form converts a one-off entry to a f
     // The entry must be listed under May 2026 (the currently viewed month when
     // the promotion happens) with the correct amount.
     await screen.findByText("May 2026");
-    expect(await screen.findByText(/Food - Coffee/)).toBeInTheDocument();
+    expect(await screen.findByText(/Coffee/)).toBeInTheDocument();
     // $90.00 appears twice: the entry's own amount and the section total.
     expect(screen.getAllByText("$90.00")).toHaveLength(2);
 
@@ -239,7 +239,7 @@ describe("toggling recurring ON in the edit form converts a one-off entry to a f
     // The "Add Expenses" link is only rendered on the dashboard.
     await screen.findByRole("link", { name: /add expenses/i });
     await user.click(screen.getByRole("link", { name: /^Expenses \$/ }));
-    expect(await screen.findByText(/Food - Coffee/)).toBeInTheDocument();
+    expect(await screen.findByText(/Coffee/)).toBeInTheDocument();
   });
 });
 
@@ -254,7 +254,7 @@ describe("unsetting recurring in the edit form removes from that month forward",
     await user.click(screen.getByRole("link", { name: /fixed entries/i }));
     await screen.findByText("March 2026");
     await goToNextMonth(user, "April 2026");
-    await user.click(await screen.findByText(/Food - Groceries/));
+    await user.click(await screen.findByText(/Groceries/));
     // The recurring toggle is on by default when editing a fixed entry.
     const toggle = await screen.findByLabelText(/recurring/i);
     expect((toggle as HTMLInputElement).checked).toBe(true);
@@ -265,12 +265,12 @@ describe("unsetting recurring in the edit form removes from that month forward",
     // April no longer shows Groceries.
     await screen.findByText("April 2026");
     await waitFor(() =>
-      expect(screen.queryByText(/Food - Groceries/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Groceries/)).not.toBeInTheDocument()
     );
 
     // March still has Groceries (forward-only removal).
     await goToPrevMonth(user, "March 2026");
-    expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
+    expect(await screen.findByText(/Groceries/)).toBeInTheDocument();
   });
 });
 
@@ -289,13 +289,13 @@ describe("fixed (recurring) entries reuse the regular entry flow (issue #103)", 
     // expenses for March.
     await user.click(screen.getByRole("link", { name: /fixed entries/i }));
     await screen.findByText("March 2026");
-    expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
-    expect(screen.getByText(/Food - Snacks/)).toBeInTheDocument();
+    expect(await screen.findByText(/Groceries/)).toBeInTheDocument();
+    expect(screen.getByText(/Snacks/)).toBeInTheDocument();
 
     // They recur into the following months automatically.
     await goToNextMonth(user, "April 2026");
-    expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
-    expect(screen.getByText(/Food - Snacks/)).toBeInTheDocument();
+    expect(await screen.findByText(/Groceries/)).toBeInTheDocument();
+    expect(screen.getByText(/Snacks/)).toBeInTheDocument();
   });
 
   it("edits and removes a recurring entry from the viewed month forward", async () => {
@@ -310,7 +310,7 @@ describe("fixed (recurring) entries reuse the regular entry flow (issue #103)", 
 
     // Edit "Snacks" while viewing April → 75 from April forward.
     await goToNextMonth(user, "April 2026");
-    await user.click(await screen.findByText(/Food - Snacks/));
+    await user.click(await screen.findByText(/Snacks/));
     const amountInput = await screen.findByPlaceholderText(
       /insert expense amount/i
     );
@@ -331,19 +331,19 @@ describe("fixed (recurring) entries reuse the regular entry flow (issue #103)", 
     // Remove "Groceries" while viewing May → gone from May, kept in March.
     await goToNextMonth(user, "April 2026");
     await goToNextMonth(user, "May 2026");
-    await user.click(await screen.findByText(/Food - Groceries/));
+    await user.click(await screen.findByText(/Groceries/));
     await user.click(
       await screen.findByRole("button", { name: /remove entry/i })
     );
 
     await screen.findByText("May 2026");
     await waitFor(() =>
-      expect(screen.queryByText(/Food - Groceries/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Groceries/)).not.toBeInTheDocument()
     );
     // March still has Groceries.
     await goToPrevMonth(user, "April 2026");
     await goToPrevMonth(user, "March 2026");
-    expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
+    expect(await screen.findByText(/Groceries/)).toBeInTheDocument();
   });
 });
 
@@ -441,7 +441,7 @@ describe("Fixed Entries totals (issue #113)", () => {
 
     // Edit "Snacks" while viewing April → 75 from April forward.
     await goToNextMonth(user, "April 2026");
-    await user.click(await screen.findByText(/Food - Snacks/));
+    await user.click(await screen.findByText(/Snacks/));
     const amountInput = await screen.findByPlaceholderText(
       /insert expense amount/i
     );

--- a/src/integrationTests/navigation.test.tsx
+++ b/src/integrationTests/navigation.test.tsx
@@ -15,13 +15,16 @@ afterEach(() => {
 });
 
 describe("navigation", () => {
-  it("does not show a Prev button when there is no data", async () => {
-    // localStorage has no entries — the app should show only the current month
-    // with no possibility to navigate to previous months
+  it("disables the Prev button when there is no earlier data", async () => {
+    // localStorage has no entries — the app shows only the current month. The
+    // stepper stays in place but is disabled rather than vanishing, so it never
+    // teleports under the thumb at the data edge.
     await renderApp("/");
 
     await screen.findByText("May 2026");
-    expect(screen.queryByRole("button", { name: /prev/i })).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /prev/i })
+    ).toBeDisabled();
   });
 
   it("shows the current month (May 2026) when opening the app", async () => {

--- a/src/integrationTests/singleFileBackup.test.tsx
+++ b/src/integrationTests/singleFileBackup.test.tsx
@@ -293,13 +293,13 @@ describe("restore — fixed entries", () => {
     await screen.findByText("May 2026");
 
     // May: Snacks was cancelled (tombstone), Groceries still recurs.
-    expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
-    expect(screen.queryByText(/Food - Snacks/)).not.toBeInTheDocument();
+    expect(await screen.findByText(/Groceries/)).toBeInTheDocument();
+    expect(screen.queryByText(/Snacks/)).not.toBeInTheDocument();
 
     // April (before the tombstone): both same-category recurring entries exist.
     await goToPrevMonth(user, "April 2026");
-    expect(await screen.findByText(/Food - Groceries/)).toBeInTheDocument();
-    expect(screen.getByText(/Food - Snacks/)).toBeInTheDocument();
+    expect(await screen.findByText(/Groceries/)).toBeInTheDocument();
+    expect(screen.getByText(/Snacks/)).toBeInTheDocument();
   });
 
   it("preserves a fixed entry's identity so a restored recurring entry can be edited", async () => {
@@ -330,7 +330,7 @@ describe("restore — fixed entries", () => {
 
     // Clicking a materialised fixed entry routes to its edit form via `fixedId`;
     // that only works if the restored entry kept its identity.
-    await user.click(await screen.findByText(/Food - Gym/));
+    await user.click(await screen.findByText(/Gym/));
 
     const amountInput = (await screen.findByPlaceholderText(
       /insert expense amount/i
@@ -479,7 +479,12 @@ describe("round trip — download produces a single JSON file that restores the 
     // Fixed entries came back and materialise into the month.
     await clickNav(user, /fixed entries/i);
     await screen.findByText("May 2026");
-    expect(await screen.findByText(/Rent - Rent/)).toBeInTheDocument();
+    // The fixed "Rent" entry has category "Rent" and description "Rent", now
+    // rendered as a stacked two-line row — so "Rent" appears twice (title +
+    // note), confirming the described row materialised.
+    expect((await screen.findAllByText(/^Rent$/)).length).toBeGreaterThanOrEqual(
+      2
+    );
   });
 });
 
@@ -497,11 +502,11 @@ describe("restore — committed sample backup file", () => {
     // cancelled as a fixed expense from May forward, so it must NOT appear here.
     await clickNav(user, /fixed entries/i);
     await screen.findByText("May 2026");
-    const netflix = await screen.findByText(/Subscriptions - Netflix/);
+    const netflix = await screen.findByText(/Netflix/);
     expect(netflix).toBeInTheDocument();
     expect(screen.getByText("$18.00")).toBeInTheDocument();
     expect(
-      screen.queryByText(/Subscriptions - Spotify/)
+      screen.queryByText(/Spotify/)
     ).not.toBeInTheDocument();
 
     // The sample also exercises "Pet Care", a user-created category (no seed
@@ -509,7 +514,7 @@ describe("restore — committed sample backup file", () => {
     // rendered through lodash's `capitalize` (only the first letter is
     // capitalized), so this is matched case-insensitively.
     expect(
-      await screen.findByText(/Pet Care - Dog food/i)
+      await screen.findByText(/Dog food/i)
     ).toBeInTheDocument();
     expect(screen.getByText("$25.00")).toBeInTheDocument();
 
@@ -532,7 +537,7 @@ describe("restore — committed sample backup file", () => {
     await clickNav(user, /home/i);
     await clickNav(user, /^Expenses \$/);
     expect(
-      await screen.findByText(/Hobby - Painting supplies/)
+      await screen.findByText(/Painting supplies/)
     ).toBeInTheDocument();
   });
 });

--- a/src/integrationTests/summaryFilters.test.tsx
+++ b/src/integrationTests/summaryFilters.test.tsx
@@ -30,6 +30,8 @@ const seedMayMonth = () =>
 const ROW_TEXT =
   /monthly paycheck|gift money|coffee beans|gift wrap|rent paid/i;
 
+// Rows render the description as its own line (candidate 4), so ROW_TEXT
+// matches the note span and its text is the row's description in visible order.
 const getVisibleRowOrder = () =>
   screen.getAllByText(ROW_TEXT).map((row) => row.textContent);
 
@@ -76,11 +78,11 @@ describe("/summary - one shared filter drives both lists", () => {
 
     // Default: each list date-descending, incomes first.
     expect(getVisibleRowOrder()).toEqual([
-      "Salary - Monthly paycheck",
-      "Deposit - Gift money",
-      "Food - Coffee beans",
-      "Fun activities - Gift wrap",
-      "House (rent) - Rent paid",
+      "Monthly paycheck",
+      "Gift money",
+      "Coffee beans",
+      "Gift wrap",
+      "Rent paid",
     ]);
 
     await user.click(screen.getByRole("button", { name: "Sort entries" }));
@@ -89,11 +91,11 @@ describe("/summary - one shared filter drives both lists", () => {
     );
 
     expect(getVisibleRowOrder()).toEqual([
-      "Salary - Monthly paycheck",
-      "Deposit - Gift money",
-      "House (rent) - Rent paid",
-      "Fun activities - Gift wrap",
-      "Food - Coffee beans",
+      "Monthly paycheck",
+      "Gift money",
+      "Rent paid",
+      "Gift wrap",
+      "Coffee beans",
     ]);
   });
 
@@ -121,7 +123,7 @@ describe("/summary - filtered banner with net total", () => {
     await goToSummary(user);
 
     // Unfiltered: the month tile shows the plain total.
-    expect(screen.getByText(/may total:/i)).toBeInTheDocument();
+    expect(screen.getByText(/may total/i)).toBeInTheDocument();
 
     // "gift" matches one income (300) and one expense (15): net +285.
     await user.type(await getToolbarSearch(), "gift");
@@ -129,7 +131,7 @@ describe("/summary - filtered banner with net total", () => {
     expect(
       await screen.findByText("Filtered view · both lists")
     ).toBeInTheDocument();
-    expect(screen.queryByText(/may total:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/may total/i)).not.toBeInTheDocument();
     expect(screen.getByText("2 of 5 entries")).toBeInTheDocument();
     expect(screen.getByText("Filtered total · net")).toBeInTheDocument();
     expect(screen.getByText("+$285.00")).toBeInTheDocument();
@@ -206,14 +208,14 @@ describe("/summary - filtered banner with net total", () => {
     await user.type(await getToolbarSearch(), "gift");
     await user.click(screen.getByRole("button", { name: "Clear" }));
 
-    expect(await screen.findByText(/may total:/i)).toBeInTheDocument();
+    expect(await screen.findByText(/may total/i)).toBeInTheDocument();
     expect(
       screen.queryByText("Filtered view · both lists")
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Sort entries" })
     ).toHaveTextContent("Sort: Date");
-    expect(getVisibleRowOrder()[0]).toBe("Salary - Monthly paycheck");
+    expect(getVisibleRowOrder()[0]).toBe("Monthly paycheck");
   });
 });
 
@@ -305,6 +307,6 @@ describe("/summary - empty state", () => {
     await user.click(screen.getByRole("button", { name: "Clear all filters" }));
 
     expect((await screen.findAllByText(ROW_TEXT)).length).toBe(5);
-    expect(screen.getByText(/may total:/i)).toBeInTheDocument();
+    expect(screen.getByText(/may total/i)).toBeInTheDocument();
   });
 });

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -68,6 +68,16 @@ $nav-breakpoint: 768px; // below this the nav becomes the bottom tab bar
 $shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3);
 $shadow-pop: 0 12px 32px rgba(0, 0, 0, 0.45);
 
+// A whisper-faint gold wash anchored to the top of the page column. Painted
+// once on `body` at a fixed size so it never stretches with page height or
+// repaints on scroll — it warms the near-black ground without touching the
+// contrast of anything drawn on a surface above it.
+$glow-page: radial-gradient(
+  90rem 40rem at 50% -6rem,
+  rgba(240, 185, 11, 0.05),
+  transparent 62%
+);
+
 // Chevron affordance shared by the native selects (global.scss) and the
 // searchable category dropdown's trigger (CategorySearchSelect) — single
 // source of truth so the two can never drift.
@@ -116,6 +126,14 @@ $transition-quick: 140ms ease;
 @mixin interactive-card {
   @include card();
   @include card-interactions();
+}
+
+// Fixed-width figures for money columns, so right-aligned digits line up in a
+// grid instead of drifting row to row. Applied to every amount, total, balance
+// and bucket number.
+@mixin money-figures {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
 }
 
 // Circular icon chip used beside money rows (income/expense variants are


### PR DESCRIPTION
Implements the approved **Expenses Tracker — Visual Refresh** design board as a single, reviewable change. All eight candidates plus the shared token/primitive foundation are included. No behavior beyond the visuals changes, except the two deliberate a11y-affecting tweaks called out below.

> Branch note: the work lives on `claude/visual-refresher-v1-xsw9m9` (the session's designated branch), which corresponds to the requested `visual-refresher-v1`.

## What's in it

**Foundation (phase A)**
- `$glow-page` token and a `money-figures` mixin in `variables.scss`
- `GlyphIcon` — a dependency-free 2px-stroke SVG glyph set (matches the codicon chevrons already in the header)
- `categoryIcons` — a category→glyph map beside the seed lists, with a unit test asserting every seed category resolves and unknowns fall back
- `BrandMark` / `public/logo.svg` — one SVG source for the mark

**Candidates**
1. **Category-aware entry icons** — each row's chip shows a glyph keyed to its category; the income-green / expense-rose tint still carries direction; custom categories fall back to today's arrow (never a broken chip).
2. **Month navigator** — rounded-square steppers (circles stay reserved for money chips); at the first/last month with data the stepper stays **visible-but-disabled** instead of vanishing.
3. **Brand mark** — vector header lockup + SVG favicon from the single source; raster `logo192/512.png` and `favicon.ico` remain as fallbacks pending brand sign-off before regenerating them.
4. **Two-line entry rows** — a described entry stacks category (semibold) over its note (muted); a bare entry keeps one line. Content-driven, so rows never reshape on resize.
5. **Whisper-faint gold page glow** — one fixed radial wash at the top of the page, under every surface layer (touches no content contrast). Guard: drop it, don't brighten it, if it bands on OLED.
6. **Tabular figures** — amounts, totals, the balance hero and bucket numbers now use fixed-width digits so columns line up.
7. **Navigation** — destination glyphs (grid for Categories, a bucket for Buckets) and a compact active indicator behind the icon instead of a full-width tint.
8. **Two-tier total tile** — `/summary`, `/expenses`, `/incomes` show a muted label + large tone-colored value on a soft-tinted card (neutral at zero).

## Deliberate behavior changes (please eyeball)
- **Disabled edge stepper** (candidate 2): a screen reader now announces the disabled Prev/Next at the data edge where the old hidden placeholder was silent. Tests updated accordingly.
- **Row / tile DOM** (candidates 4 & 8) now split category/note and label/value into separate elements; integration assertions that matched the old joined strings were updated to the visible parts.

## Verification
- Integration suite: **140 passed** (`npm test -- --testPathPattern="integrationTests"`)
- `categoryIcons` unit test: 3 passed
- `npm run typecheck`: clean · `npm run lint`: 0 errors (pre-existing warnings only)
- `npm run build`: compiles (SCSS included)

## Not done here (by design)
- Regenerating the raster PWA PNG icons from the new SVG — the board gates the brand raster on identity sign-off (phase D), and no rasterizer is available in this environment. The vector header + SVG favicon ship now; the PNGs stay as fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158NtMoT82FauUoiag5CsiU

---
_Generated by [Claude Code](https://claude.ai/code/session_0158NtMoT82FauUoiag5CsiU)_