### PR TITLE
Multi-user sync [1/9]: planning docs (PRD, DESIGN, RFC, TASKS, TEST-PLAN)

### DIFF
--- a/docs/multi-user-sync/DESIGN.md
+++ b/docs/multi-user-sync/DESIGN.md
@@ -1,0 +1,447 @@
+# Design Spec: Multi-User Sync
+
+Status: Ready for Tech Lead review
+Inputs: `PRD.md` (AC/EC refs below), `feature-brief.md`, existing design system
+(`src/variables.scss`, `Header`, `DataManagement`, `MainContentContainer`,
+`Forms.js`, `EntryForm`, `Buckets`, dormant `SignIn`/`SignUp`).
+
+Tone: plain and reassuring, matching existing copy ("Keep your data safe",
+"This cannot be undone"). No new colors, radii, or shadows — every screen
+below is built from tokens already in `variables.scss`.
+
+## 1. Information architecture
+
+**Decision: no new bottom-tab item.** The tab bar is already full (Home,
+Categories, Buckets, Fixed Entries, Data) and AC-1.7/NFR-3 require the app to
+stay fully usable without ever touching this feature — it shouldn't tax the
+primary nav for users who never sign up.
+
+- **Account entry point:** a small circular icon-button added to
+  `app-header__bar` (the row that already holds the brand/logo), right-aligned
+  via the existing `justify-content: space-between`. It is present at every
+  viewport, independent of the bottom tab bar's breakpoint collapse. Shows a
+  generic account glyph when logged out, or the user's initials in an
+  `$accent-soft` chip when logged in. Route: `/account`.
+- **Party** is reached from `/account` (you need an account before a party
+  makes sense) — not a nav item of its own.
+- **Sync** lives on the existing Data Management screen (`/data-management`),
+  as a new card between "Keep your data safe" and "Danger zone" — sync is
+  another way of keeping data safe, so it reads as a natural extension of
+  that screen rather than a new destination. The review wizard is a full
+  screen the Sync button pushes to: `/sync-review`.
+
+Routes (all mounted inside `Dashboard`'s existing `<Switch>`, so `Header` and
+the nav stay visible everywhere, exactly like `/data-management` today):
+
+| Route | Screen |
+|---|---|
+| `/account` | Account hub (logged-out or logged-in view) |
+| `/sign-up` | Sign Up form |
+| `/sign-in` | Sign In form |
+| `/party` | Party hub (no-party / member / organizer / canceled / blocked views) |
+| `/party/invite` | Organizer: generate invitation |
+| `/party/join` | Invitee: redeem invitation |
+| `/data-management` | unchanged, +Sync card (AC-3.7) |
+| `/sync-review` | Review wizard |
+
+Nothing here gates any existing route. `AuthenticatedApp` stays commented out;
+`WithBalance` keeps loading entries directly regardless of session state.
+
+## 2. Auth screens
+
+Decision: **retire the standalone `NoSessionContainer`/`Lobby` full-page
+takeover pattern for this feature.** That pattern assumes auth gates the
+whole app; here auth is optional and additive, so Sign Up/Sign In should look
+like every other in-app screen (`MainContentContainer` + `Forms.js`), not a
+separate unthemed shell. Reuse `SignIn`/`SignUp`'s validation logic
+(`FormValidation`/`FormModel`/`ValidateField`) as-is; replace their JSX
+wrapper.
+
+### 2.1 `/account` — logged out
+
+```
+┌ Account ─────────────────────────┐
+│ Sign in to sync your entries      │
+│ across devices with your party.   │
+│ [        Sign in        ] primary │
+│ [        Sign up      ] secondary │
+│ Everything still works without    │
+│ an account — this is only needed  │
+│ for syncing with a party.         │
+└────────────────────────────────────┘
+```
+`MainContentContainer pageTitle="Account"`, one `ContentTileSection`-style
+static card holding the two `FormButton`s (`btn-primary` / `btn-secondary`),
+plus a `text-secondary` reassurance line (AC-1.7).
+
+### 2.2 `/sign-up`, `/sign-in`
+
+Same fields/validation as today's `SignUp.js`/`SignIn.js`, wrapped in
+`MainContentContainer pageTitle="Sign up"` / `"Sign in"` instead of
+`NoSessionContainer`. Submit = `FormButton variant="primary"`, disabled
+until `formState.isModelValid` (existing pattern). Add a `Cancel` /
+`Button variant="secondary"` that calls `history.goBack()` (matches
+`EditBucket`/`DataManagement`).
+
+States:
+- **Loading:** submit button label becomes "Signing up…" / "Signing in…",
+  `disabled` (reuse `SignUp`'s existing `isLoading` ternary; add the same to
+  `SignIn`).
+- **Errors** (AC-1.5), rendered as a `role="alert"` paragraph above the
+  submit button, same class as `restore-backup-error`:
+  - Duplicate email: *"An account with this email already exists. Try
+    signing in instead."* with a `Sign in` text link.
+  - Wrong credentials: *"Email or password is incorrect."* — deliberately
+    generic, never says which field was wrong (AC-1.5).
+- Sign Up's `Cancel` and Sign In's implicit dead-end both return to
+  `/account`.
+
+### 2.3 `/account` — logged in
+
+```
+┌ Account ─────────────────────────┐
+│  (JD)  Jane Doe                   │
+│        jane@example.com           │
+│ [        Party         ] →        │
+│ [       Log out       ] secondary │
+└────────────────────────────────────┘
+```
+`(JD)` = initials chip (`$accent-soft` bg, `$accent` text, same shape as the
+header icon). "Party" row is a `ContentTileSection to="/party"` (chevron
+affordance, reused as-is). Logout: `Button variant="secondary"`, no confirm
+dialog (reversible, low-stakes) — on success, re-render the logged-out view
+of the same screen with a transient `role="status"` line: *"Signed out. Your
+data stays on this device."* (AC-1.4).
+
+## 3. Party screens
+
+### 3.1 `/party` — no party yet (logged in)
+
+```
+┌ Party ───────────────────────────┐
+│ Create a party                    │
+│ Start a party to sync entries     │
+│ with family members.              │
+│ [   Create a party   ] primary    │
+│ Join a party                      │
+│ Have an invitation code? Join     │
+│ the party that invited you.       │
+│ [   Join a party    ] secondary   │
+└────────────────────────────────────┘
+```
+Two `.data-section`-style cards (reusing `DataManagement`'s
+`@include card()` block), matching its "explanatory text above a button"
+shape exactly.
+
+- **Create a party** (AC-2.1) needs no input — reuse the `window.confirm`
+  pattern already used by "Clear all data": *"Create a party? You'll become
+  its organizer and can invite family members."* [OK/Cancel]. On confirm,
+  the party is created and the screen re-renders as 3.2. The party is
+  labeled for display only as *"{first name}'s Party"* — no name field, no
+  extra step.
+- **Join a party** routes to `/party/join` (3.4).
+
+### 3.2 `/party` — organizer view
+
+```
+┌ Party ───────────────────────────┐
+│ Jane's Party            Organizer │
+├────────────────────────────────────┤
+│ Jane Doe (you)          Organizer │
+│ Tom Doe                  [Block]  │
+│ Sam Doe                 Blocked   │
+├────────────────────────────────────┤
+│ [   Add a member    ] primary     │
+│ [   Cancel party    ] danger      │
+└────────────────────────────────────┘
+```
+Member list = stacked rows (new `MemberRow`, styled like `Bucket`'s row but
+static, no `RowLink` navigation): name/email, and a right-aligned status —
+`Organizer` badge (`$accent` text, no background) for the creator, a
+`Block` button (`Button variant="secondary"`, AC-2.9) for active members
+other than self, or a muted `Blocked` label for already-blocked ones (no
+un-block affordance — out of scope). Clicking `Block` uses the same confirm
+pattern: *"Block Tom Doe? They'll immediately lose the ability to sync.
+Entries they've already contributed stay in the party's history."*
+
+Bottom actions, **organizer-only** (AC-2.12): `Add a member` → `/party/invite`
+(this is also the "add user directly" action — AC-2.8 and invite are the
+same flow, since both end in an out-of-band token+password); `Cancel party`
+→ `Button variant="danger"`, confirm: *"Cancel Jane's Party? No member will
+be able to sync afterward. Nobody's local data is deleted."* (AC-2.10).
+
+**Empty state** (organizer, no members yet): the list shows only the
+organizer's own row, plus a `text-secondary` line under it: *"Invite family
+members to start syncing."* No new illustration asset — text + existing
+icon only, unlike `Buckets`' empty state which already had bespoke art.
+
+### 3.3 `/party` — member (non-organizer) view
+
+Same member list, read-only (no `Block` buttons, no bottom actions — AC-2.12).
+Add one `text-secondary` line at the bottom: *"Only Jane, the organizer, can
+add or remove members."*
+
+### 3.4 `/party/invite` — organizer generates an invitation
+
+```
+Step 1                          Step 2 (same route, state swap)
+┌ Add a member ──────┐          ┌ Add a member ────────────────┐
+│ Set an invitation   │          │ Invitation ready              │
+│ password             │  ───▶   │ Code  [ K7X9-QP2M   ] [Copy]  │
+│ [ ......... ] pwd    │          │ Pwd   [ •••••••••••  ] [Copy] │
+│ [Generate invite]    │          │ Share code & password over    │
+└──────────────────────┘          │ different channels.           │
+                                   │ [        Done       ]secondary│
+                                   └────────────────────────────────┘
+```
+Step 1: a single `InputPassword` (organizer chooses it, AC-2.3), `FormButton`
+"Generate invitation". Step 2: the token renders as a short uppercase code
+(monospace `InputText readOnly`) next to a `Copy` icon button
+(`codicon:copy`); same for the password (masked, `codicon:eye` reveal toggle,
+`InputPassword`'s existing type). Tapping `Copy` shows a 2-second inline
+*"Copied"* confirmation (`aria-live="polite"` — no toast primitive exists in
+the app, so this avoids introducing one). `Done` returns to `/party`. Nothing
+here is ever logged; token/password only exist in component state and the
+encrypted invitation record (AC-2.4/NFR-2).
+
+### 3.5 `/party/join` — invitee redeems an invitation
+
+```
+┌ Join a party ────────────────────┐
+│ [ Invitation code    ] text       │
+│ [ Password            ] password  │
+│ [        Join         ] primary   │
+│ [       Cancel       ] secondary  │
+└────────────────────────────────────┘
+```
+Same `FormValidation`/`Forms.js` shape as Sign In. Submit disabled until both
+fields are non-empty. Errors, `role="alert"`, invitation-specific and never
+technical:
+- Wrong password (EC-7): *"That password doesn't match this invitation.
+  Double-check it with whoever invited you and try again."* — code/password
+  fields stay filled so the user can retry immediately; the invitation is
+  **not** burned (AC-2.5).
+- Reused token (EC-8): *"This invitation has already been used. Ask the
+  organizer to send you a new one."*
+- Already in a party (EC-6): normally unreachable — AC-2.2 means `/party`
+  never offers this route to a member — but kept as a defensive message for
+  a stale tab: *"You already belong to a party. Refresh to see it."*
+
+On success: redirect to `/party` (now rendering the member view, 3.3).
+
+### 3.6 Blocked / canceled-party views
+
+Both reuse the no-party CTA layout from 3.1 (no member list) — being blocked
+or losing a canceled party both leave the user free to create/join
+elsewhere:
+- Blocked: *"You've been removed from this party by its organizer."*
+- Canceled: *"Your party was canceled. Create or join a new one to sync
+  again."*
+
+## 4. Sync flow (`/data-management`)
+
+New card, same shape/order as the existing two `.data-section` cards:
+
+```
+┌ Data Management ─────────────────┐
+│ Keep your data safe   (existing)  │
+│ ...                                │
+├────────────────────────────────────┤
+│ Sync with your party               │
+│ Pull in what your family added,    │
+│ review it, then merge it in.       │
+│ [    Sync with party   ] primary   │
+│ Last synced: 3 days ago            │  ← or "Never synced yet"
+├────────────────────────────────────┤
+│ Danger zone            (existing)  │
+└────────────────────────────────────┘
+```
+
+### 4.1 Button enabled/disabled logic (AC-2.11)
+
+The button uses a native `disabled` attribute (same pattern as `SignIn`'s
+`disabled={!formState.isModelValid}`) so it's visually inert, but the
+explanatory copy is a **permanent, always-rendered `text-secondary`
+paragraph directly under the button** — never a tooltip or hover-only
+hint — so it reaches screen readers regardless of the button's focus state
+("not silently hidden", AC-2.11):
+
+| State | Copy under the button |
+|---|---|
+| Logged out | "Sign in and join a party to sync your entries across devices." |
+| Logged in, no party | "Create or join a party to start syncing." |
+| Party canceled | "Your party was canceled. Create or join a new one to sync again." |
+| Blocked (AC-2.9/EC-9) | "You've been removed from your party by its organizer. Sync is unavailable." |
+| Enabled | "Last synced: {relative date}" / "Never synced yet" (not a warning — muted caption) |
+
+### 4.2 Sync button states
+
+- **Idle/enabled:** "Sync with party".
+- **In progress:** label → "Syncing…", spinner, `disabled`,
+  `aria-live="polite"` region announces "Syncing with your party…".
+- **Nothing new (AC-3.3):** inline `role="status"` banner appears under the
+  card, button returns to idle: *"You're up to date."*
+- **First sync for the party, no remote backup yet (EC-1):** local state
+  uploads automatically as the initial backup, wizard skipped, distinct
+  confirmation (still success, never framed as an error): *"This is the
+  first sync for your party. Your data is now the starting point — future
+  syncs will compare against it."*
+- **Incoming changes:** navigates to `/sync-review`.
+- **Download failed:** `role="alert"` banner: *"Couldn't reach your party.
+  Check your connection and try again."* Button re-enabled, label back to
+  "Sync with party" (AC-3.11 — nothing local touched, so simple retry).
+
+### 4.3 The review wizard (`/sync-review`)
+
+**Staging model (resolves AC-3.6 vs AC-3.11):** decisions made while
+reviewing (accept/reject/modify) are held in the wizard's local state only.
+Nothing is written to real `localStorage` until the final upload succeeds
+(4.3.4). This makes "nothing applied until review completes," mid-wizard
+cancel, and "failed upload leaves local data untouched" all the same simple
+rule instead of three special cases — worth the Tech Lead confirming the
+sync engine can expose a staged/dry-run merge this way.
+
+Because nothing is committed until upload succeeds, **the bottom tab bar and
+header stay interactive during the wizard**: navigating away mid-review is
+always a safe, silent abandonment (equivalent to Cancel, just without the
+confirmation prompt). The in-wizard "Cancel review" control below exists
+only to make that abandonment a deliberate, confirmed choice so users don't
+lose review progress by accident.
+
+#### 4.3.1 Item card — one item at a time (AC-3.4)
+
+```
+┌ Review changes ───────────────────┐
+│ ▓▓▓▓▓▓▓▓░░░░░░░░░░░░  Item 3 of 12 │
+│ [Accept all]          [Reject all] │
+├─────────────────────────────────────┤
+│ ● Expense            Added by Tom  │
+│  $42.10                            │
+│  Groceries                         │
+│  Household, eating out             │
+│  Jul 10, 2026                      │
+│ [ Accept ]  [ Modify ]  [ Reject ] │
+└─────────────────────────────────────┘
+```
+- Progress: native `<progress>` (same element `Bucket` already uses) plus
+  visible text "Item 3 of 12"; the *text* (not the bar) sits in an
+  `aria-live="polite"` region so screen readers hear only the count change,
+  not the whole card re-read on every advance.
+- Kind badge: small dot + label — "Income"/"Expense"/"Fixed Income"/"Fixed
+  Expense"/"Bucket" — colored with `$income`/`$expense`/`$accent`
+  respectively (reuses existing semantic colors, no new ones).
+- Attribution: *"Added by {first name}"*, right-aligned, `text-secondary`
+  (AC-1.6/3.4).
+- Body fields: amount (colored `$income`/`$expense` like every other money
+  row in the app), description, category path pretty-printed (split on the
+  `,` segments, e.g. `Household, eating out`), date formatted `MMM D, YYYY`
+  (`dayjs`, same library already used in `helpers/date.js`). A bucket item
+  shows its name + monthly allowance instead of the four entry fields.
+- Actions: `Accept` (`btn-primary`), `Modify` (`btn-secondary`), `Reject`
+  (styled like the existing `.btn.btn-danger` — transparent bg, rose border,
+  since it's a common, not scary, action). Each gets a full accessible name,
+  e.g. `aria-label="Accept $42.10 expense added by Tom"`, so the visible
+  short labels stay clean for sighted users while screen-reader users get
+  the specific item.
+- Choosing any action auto-advances to the next item and moves DOM focus to
+  the new card's container (`tabIndex={-1}` + `.focus()`), so the next
+  card's content is read in natural order without relying solely on the
+  `aria-live` progress text.
+
+#### 4.3.2 Modify (AC-3.6, EC-5)
+
+Tapping `Modify` swaps the card body in place (no navigation) for the same
+field set `EntryForm` already uses — `InputNumber` (amount), `InputText`
+(description), `CategorySelector` (category) — plus one genuinely new field,
+a plain `InputDate` (native `type="date"`, styled like the other `Forms.js`
+inputs; no date picker exists in the app today and a native input is the
+smallest addition that fits). Actions become `Save & accept` (primary) /
+`Cancel` (secondary, discards the edit and returns to the read-only card
+without recording a decision). Saving records the item as **accepted with
+the edited values** — the modified value, not the original, is what's staged
+(EC-5).
+
+#### 4.3.3 Accept all / Reject all (AC-3.5)
+
+Two small secondary text buttons pinned under the progress bar, always
+visible, acting on *all remaining unreviewed items* (not the whole set —
+already-decided items are untouched). Both reuse the `window.confirm`
+pattern:
+- *"Accept the remaining 9 items without reviewing them individually?"*
+- *"Reject the remaining 9 items without reviewing them individually?"*
+
+Confirming jumps straight to the summary (4.3.4).
+
+#### 4.3.4 Summary → upload → success
+
+```
+┌ Review complete ─────────────────┐
+│ 8 accepted · 1 modified · 3       │
+│ rejected                          │
+│ [   Upload & finish   ] primary   │
+│ [   Cancel review    ] secondary  │
+└────────────────────────────────────┘
+```
+Reached after the last item or after Accept/Reject All. `Upload & finish`
+commits the staged merge to `localStorage` and uploads it as the party's new
+backup in one step (AC-3.8):
+- **Uploading:** button → "Saving…", disabled, `aria-live="polite"`
+  announces "Saving your changes…".
+- **Success:** screen swaps to *"Synced! Your party is up to date."* with a
+  single `Done` button (`FormButton variant="primary"`) → `/data-management`.
+  No auto-redirect — explicit `Done` keeps the confirmation on screen long
+  enough to read, matching how `Restore Backup` pushes `history.push("/")`
+  only after its own async step resolves, not eagerly.
+- **Upload failed (AC-3.11/EC-3):** stays on the summary screen, adds a
+  `role="alert"` line above the buttons: *"Couldn't save your changes to
+  your party. Check your connection and try again."* `Upload & finish`
+  becomes `Retry` — it re-attempts the same staged decision set without
+  re-running review. Local data is untouched (nothing was committed pre-
+  upload, per the staging model above).
+
+**Cancel review** (available on the summary, and as a smaller text link on
+every item card): confirm dialog — *"Stop reviewing? None of your choices in
+this session will be saved. You can sync again anytime."* [Stop
+reviewing/Keep reviewing]. Confirming discards all staged decisions and
+returns to `/data-management` with no message (there's nothing to report —
+local state never changed). A later sync re-downloads and re-presents every
+still-outstanding item from scratch.
+
+## 5. Accessibility summary
+
+- **Focus management:** wizard route mount → focus the screen `h1`. Each item
+  advance (accept/reject/save-and-accept) → focus the next card container.
+- **`aria-live="polite"`:** progress count text, sync-in-progress/uploading
+  status text, "Copied" confirmations on the invite screen.
+- **`role="alert"`:** every error state (auth, invitation, download/upload
+  failure) — reuses the exact `restore-backup-error` class/role already in
+  `DataManagement`.
+- **`role="status"`:** non-error confirmations ("You're up to date.",
+  "Signed out.", first-sync confirmation) — announced without interrupting.
+- **Button names:** header account icon gets `aria-label="Account"` (logged
+  out) / `"Account: Jane Doe"` (logged in), matching how `Header`'s nav items
+  already carry explicit `aria-label`s. Wizard actions get item-specific
+  `aria-label`s (4.3.1).
+- **Contrast/touch targets:** no new colors — every pairing above reuses
+  `$text-primary`/`$text-secondary`/`$danger`/`$income`/`$expense` on
+  `$bg-raised`, all already validated. Buttons keep the existing `.btn` 3.1em
+  height (~50px); the new header icon button gets a 44×44px hit area.
+- **Focus rings:** every new interactive element gets `@include
+  focus-ring()`, no exceptions.
+
+## 6. Component mapping
+
+| Screen | Reused | New |
+|---|---|---|
+| Header account icon | `app-header__bar` layout, `focus-ring` mixin | icon-button + initials chip (`Header.js`/`.scss`) |
+| Account hub | `MainContentContainer`, `ContentTileSection`, `FormButton` | — |
+| Sign up / Sign in | `SignIn`/`SignUp`'s existing logic, `Forms.js`, `FormValidation` | swap `NoSessionContainer` wrapper for `MainContentContainer` |
+| Party hub / detail | `.data-section` card (`DataManagement`), `window.confirm` pattern, `RowLink`-style row shape | `MemberRow` (status-aware row, no navigation) |
+| Invite generate | `Forms.js` inputs, `codicon:copy`/`codicon:eye` icons | `InviteShareCard` (read-only field + copy button + "Copied" live text) |
+| Join party | `Forms.js`, `FormValidation` | — |
+| Sync card | `.data-section` card, `Button` variants | inline alert paragraph (info/success/error variants — small shared style, not a new component) |
+| Review wizard | `<progress>` (from `Bucket`), `Forms.js`/`CategorySelector` for Modify, `$income`/`$expense` money coloring, `window.confirm` for bulk actions | `ReviewItemCard`, `WizardProgress`, `WizardSummary`, `InputDate` (new, in `Forms.js`) |
+
+Total new components: **6** (header account chip, `MemberRow`,
+`InviteShareCard`, `ReviewItemCard`, `WizardProgress`/`WizardSummary`,
+`InputDate`) — everything else reuses existing tokens and components as-is.

--- a/docs/multi-user-sync/DESIGN.md
+++ b/docs/multi-user-sync/DESIGN.md
@@ -290,6 +290,22 @@ hint — so it reaches screen readers regardless of the button's focus state
 - **Download failed:** `role="alert"` banner: *"Couldn't reach your party.
   Check your connection and try again."* Button re-enabled, label back to
   "Sync with party" (AC-3.11 — nothing local touched, so simple retry).
+- **Rejected by the server — stale local state** (EC-9, AC-2.10/2.11): the
+  user may have been blocked, or the party canceled, *after* this screen
+  rendered. The backend rejects the attempt; never surface it as the generic
+  connection error above — that would tell a blocked user to "try again"
+  forever. Same defensive stale-state treatment as EC-6 (3.5), with distinct
+  `role="alert"` banners:
+  - Blocked: *"This sync was declined: you've been removed from your party
+    by its organizer. Nothing on this device was changed."*
+  - Canceled: *"This sync was declined: your party was canceled. Nothing on
+    this device was changed."*
+
+  After either alert, the sync card re-renders into the matching disabled
+  state from the 4.1 table (disabled button + its explanatory caption), so
+  the screen ends up exactly as if it had loaded with fresh state. The same
+  two banners and re-render apply when the rejection happens at the
+  *upload* step instead (see 4.3.4).
 
 ### 4.3 The review wizard (`/sync-review`)
 
@@ -398,6 +414,27 @@ backup in one step (AC-3.8):
   becomes `Retry` — it re-attempts the same staged decision set without
   re-running review. Local data is untouched (nothing was committed pre-
   upload, per the staging model above).
+- **Version conflict — the party backup changed mid-review (EC-2):** the
+  server's version check rejects the upload because another member synced
+  between this user's download and upload. Stays on the summary screen,
+  `role="alert"`: *"Your party synced new changes while you were reviewing.
+  Sync again to pick them up — you'll review everything fresh, including
+  what you just saw."* The primary button becomes `Sync again`: it discards
+  the staged decisions and re-runs the sync from the top (fresh download →
+  wizard). Secondary button remains `Cancel review` (returns to
+  `/data-management`, also discarding). **Staged decisions are discarded,
+  not carried forward:** the conflicting backup may contain newer versions
+  of the very items just reviewed (EC-5 — a member may have modified one),
+  so replaying stale decisions could silently accept outdated values, the
+  exact silent loss EC-2 forbids. Discarding keeps one invariant — decisions
+  apply only to the exact download they were made against — and at family
+  scale (small diffs, infrequent syncs) a re-review costs seconds. Local
+  data is untouched, as with every pre-commit failure.
+- **Rejected — blocked / party canceled (EC-9, AC-2.10):** if the user was
+  blocked or the party canceled mid-review, the upload is rejected the same
+  way a fresh sync would be. Discard staged decisions, return to
+  `/data-management`, and show the corresponding `role="alert"` banner and
+  disabled-card re-render defined in 4.2.
 
 **Cancel review** (available on the summary, and as a smaller text link on
 every item card): confirm dialog — *"Stop reviewing? None of your choices in

--- a/docs/multi-user-sync/PRD.md
+++ b/docs/multi-user-sync/PRD.md
@@ -1,0 +1,236 @@
+# PRD: Multi-User Sync
+
+Status: Draft for Tech Lead RFC
+Source of truth: `feature-brief.md` (this PRD elaborates it; brief wins on conflict)
+
+## 1. Problem & Objective
+
+The app is single-device: all data lives in `localStorage`. Families today
+reconcile spending manually via a shared Google Drive spreadsheet — slow,
+error-prone, disconnected from the app's categories/buckets.
+
+**Objective:** let a small group of related users (a "party", e.g. a
+household) each enter data on their own device and periodically reconcile
+into one shared truth via manual, reviewed sync — making the app the
+family's source of truth instead of a spreadsheet, with no requirement for
+always-on connectivity or a live backend for dev/test.
+
+This evolves the existing single-file backup/restore
+(`src/helpers/backupHelper/backupHelper.js`,
+`.../DataManagement`), not replaces it: restore-replace keeps working
+unmodified; sync adds a second, merge-based path on the same envelope shape
+(entries/balance, buckets, categories, fixedEntries).
+
+## 2. Personas
+
+- **Organizer (inviter):** creates the party, invites/adds/blocks members,
+  can cancel the party. No elevated data rights — their entries sync like
+  anyone else's.
+- **Member (invitee):** joins via invitation, adds entries on their own
+  device, syncs to reconcile with the party.
+
+The organizer is simply whichever member created the party. Party-management
+actions are organizer-only (AC-2.x).
+
+## 3. User Stories & Acceptance Criteria
+
+Numbering: `AC-<section>.<n>`.
+
+### 3.1 Accounts
+
+*As a user, I can sign up and log in, so my entries are attributed to me and
+I can join a party.*
+
+- AC-1.1: Signup/login need at minimum email + password. Auth MUST be the
+  simplest secure mechanism that satisfies these ACs — no MFA/OAuth/email
+  verification unless the RFC finds one necessary for security at
+  negligible extra cost.
+- AC-1.2: Passwords are never stored or transmitted in plaintext.
+- AC-1.3: Login persists the session across reloads and browser restarts
+  until explicit logout or session expiry.
+- AC-1.4: Logout disables sync and stops entry attribution to that account
+  until logging back in.
+- AC-1.5: Duplicate-email signup and wrong-credential login are rejected
+  with clear errors; login errors don't reveal whether the email exists.
+- AC-1.6: Every entry created while logged in records which account added
+  it — this is what the review wizard displays (AC-3.4).
+- AC-1.7: Fully logged-out use works exactly as today; sync UI is
+  hidden/disabled when logged out.
+
+### 3.2 Parties
+
+*As an organizer, I can create a party and invite family members so we can
+later sync a shared view of our finances.*
+
+- AC-2.1: A logged-in user with no party can create exactly one party and
+  becomes its organizer.
+- AC-2.2: A user belongs to **at most one** party. UI never offers to
+  join/create a second while already in one.
+- AC-2.3: Organizer generates an invitation: a token + an organizer-chosen
+  password, delivered out-of-band.
+- AC-2.4: Invitation token and password MUST be encrypted wherever stored
+  or transmitted — never persisted/logged in plaintext.
+- AC-2.5: Invitee redeems with token + password. Wrong password: rejected
+  with a clear error; invitation stays usable for a later correct attempt
+  (does not burn single-use).
+- AC-2.6: A successfully redeemed invitation becomes permanently invalid.
+  Any later redemption attempt (right or wrong password) is rejected as
+  "already used."
+- AC-2.7: Redemption adds the invitee as a member. If the invitee already
+  belongs to any party, redemption is rejected, not switched/double-joined
+  (EC-6).
+- AC-2.8: Organizer can also add a user directly (no token needed); same
+  one-party-per-user constraint applies.
+- AC-2.9: Organizer can block a member. A blocked member immediately loses
+  sync ability (AC-2.11); entries they already contributed to a prior
+  synced backup are not retroactively removed.
+- AC-2.10: Organizer can cancel the party. No member can sync against it
+  afterward; no member's local data is touched.
+- AC-2.11: Sync is usable only by a logged-in user who belongs to a party
+  and is not blocked in it. Any other state disables the sync button with
+  an explanatory message (not silently hidden).
+- AC-2.12: Invite/add/block/cancel controls are visible only to the
+  organizer.
+
+### 3.3 Sync
+
+*As a party member, I can pull in and reconcile the party's shared data with
+mine, entry by entry, so we stay in sync without losing anyone's edits.*
+
+- AC-3.1: Sync is a manual, explicit user action (button), gated by
+  AC-2.11. No automatic/background sync.
+- AC-3.2: Sync downloads the party's latest backup (same envelope shape as
+  `buildBackupEnvelope`, each item now also carrying its contributing
+  account) and diffs it against local data.
+- AC-3.3: If the download has nothing new relative to what was already
+  synced, show "already up to date" and skip the wizard (also applies to
+  the no-remote-backup-yet case producing no diff, EC-1).
+- AC-3.4: When there are incoming differences, a review wizard presents
+  each changed/new item (entry, fixed entry, or bucket), showing its
+  content, who added/changed it, and three actions: **Accept**, **Reject**,
+  **Modify** (edit before accepting).
+- AC-3.5: Wizard offers **Accept All** / **Reject All** shortcuts for all
+  remaining unreviewed items.
+- AC-3.6: Accept merges the item locally; Reject discards it (this and all
+  future syncs, AC-3.9); Modify lets the user edit the incoming value
+  before it's merged as accepted.
+- AC-3.7: The existing Restore flow (whole-state replace) is completely
+  unmodified — sync is an additive, separate path. Download Backup /
+  Restore Backup / Clear All Data behave exactly as before.
+- AC-3.8: After review completes (including via Accept/Reject All), the
+  resulting local state is uploaded as the party's new latest backup.
+- AC-3.9: Sync is idempotent: an item already present locally (own or
+  previously synced) is never re-shown or duplicated; an item the user
+  previously rejected never reappears in a later wizard and is never
+  merged in, even though it's still in the party's backup history (EC-4).
+- AC-3.10: Sync covers entries (incomes/expenses), fixed entries, and
+  buckets. Categories travel with entries/buckets as today.
+- AC-3.11: A failed download or upload (e.g. offline) leaves local data
+  completely untouched, surfaces a clear error, and never partially
+  applies a merge (EC-3).
+
+## 4. Edge Cases
+
+- **EC-1 First sync, no remote backup yet:** upload local state as the
+  initial party backup (wizard skipped, or shown pre-accepted) — confirmed
+  to the user, never an error.
+- **EC-2 Concurrent syncs by two members:** no member's already-accepted
+  entry may ever be silently lost. Last-write-wins upload is NOT
+  acceptable on its own; RFC must pick either a version/conflict check
+  that forces re-sync before upload, or an append-only history reconciled
+  on download.
+- **EC-3 Offline/failed upload:** AC-3.11.
+- **EC-4 Rejected entries reappearing:** AC-3.9 — permanent per (user,
+  item), never re-prompts.
+- **EC-5 Modify-then-sync-back:** the modified value (not the original
+  incoming one) is what's merged locally and re-uploaded (AC-3.6, 3.8); the
+  next syncer sees the modified value as current.
+- **EC-6 Invitee already in a party:** AC-2.7 — rejected, invitation NOT
+  consumed.
+- **EC-7 Wrong invitation password:** AC-2.5 — rejected, invitation stays
+  valid for retry.
+- **EC-8 Reused invitation token:** AC-2.6 — permanently rejected.
+- **EC-9 Blocked user attempting sync:** AC-2.9/2.11 — rejected, no
+  download/upload occurs.
+
+## 5. Non-Functional Requirements
+
+- **NFR-1 Cost:** cost-effective at small-family scale (few users,
+  infrequent manual syncs); prefer pay-per-use/free-tier over always-on
+  infra. Suggested Lambda/S3/DB are illustrative, not mandatory.
+- **NFR-2 Security:** invitation token + password encrypted at rest and in
+  transit (AC-2.4); user passwords never stored/logged in plaintext
+  (AC-1.2).
+- **NFR-3 No regressions:** every existing feature keeps working unchanged
+  for a user who never signs up or joins a party; existing integration
+  tests keep passing without modification unless strictly necessary and
+  directly caused by this feature.
+- **NFR-4 Local dev/test:** the whole feature (accounts, parties,
+  invitations, sync) must be runnable and testable fully locally, no live
+  AWS or paid third-party service required; production third-party
+  services need a documented local stand-in.
+- **NFR-5 Test approach:** new integration tests exercise user-visible
+  behavior (screen text/roles/buttons), not Redux state or `localStorage`
+  directly, and need no network access to a live third-party service.
+
+## 6. Out of Scope
+
+- Automatic/background sync.
+- Real-time/live collaboration.
+- Belonging to more than one party at once.
+- Conflict resolution beyond the review wizard (accept/reject/modify).
+- Any change to the existing Restore's replace semantics.
+- Organizer-ownership transfer, deleting a member's history, or editing
+  party metadata beyond create/cancel/add/block.
+- Notifications that a party backup changed — user only learns by syncing.
+
+## 7. Definition of Done
+
+- [ ] Sign up, log out, log back in; session persists across reload
+      (AC-1.1–1.3).
+- [ ] Entry's creating account is shown in the review wizard to other
+      members (AC-1.6, 3.4).
+- [ ] Logged-out/party-less user sees sync disabled with an explanation;
+      all existing features unaffected (AC-1.7, 2.11, NFR-3).
+- [ ] Organizer creates a party, generates an invitation, a second account
+      redeems it and becomes a member (AC-2.1–2.5).
+- [ ] Re-redeeming the same invitation fails as "already used" (AC-2.6,
+      EC-8).
+- [ ] Wrong invitation password fails without burning it; correct retry on
+      the same token still works (AC-2.5, EC-7).
+- [ ] A user already in a party cannot redeem another invitation or be
+      added to a second party (AC-2.7/2.8, EC-6).
+- [ ] Organizer blocks a member; that member's sync becomes disabled and a
+      sync attempt is rejected (AC-2.9, 2.11, EC-9).
+- [ ] Organizer cancels the party; no member can sync afterward; no local
+      data is deleted (AC-2.10).
+- [ ] First sync for a new party succeeds without a "no backup" error
+      (EC-1).
+- [ ] Sync with incoming changes opens the wizard with correct content and
+      attribution, working Accept/Reject/Modify and Accept All/Reject All
+      (AC-3.4, 3.5).
+- [ ] After review, local state = accepted/modified items only; this
+      becomes the new party backup (AC-3.6, 3.8).
+- [ ] Sync with nothing new shows "already up to date," no wizard (AC-3.3).
+- [ ] Re-syncing never re-shows or re-applies already-accepted or
+      already-rejected items (AC-3.9, EC-4).
+- [ ] Entries, fixed entries, and buckets all reconcile in one sync
+      (AC-3.10).
+- [ ] Simulated offline/failed upload leaves local data untouched, shows a
+      clear error, no partial merge (AC-3.11, EC-3).
+- [ ] Existing Download Backup / Restore Backup / Clear All Data behave
+      identically to before (AC-3.7, NFR-3).
+- [ ] `npm test -- --testPathPattern="integrationTests"` passes, including
+      new tests, with no live third-party network calls (NFR-4, NFR-5).
+- [ ] `npm run typecheck` and `npm run lint` pass.
+- [ ] No password or invitation token/password appears in plaintext in
+      storage, logs, or network payloads (NFR-2).
+- [ ] `package.json`/`package-lock.json` version bumped, `CHANGELOG.md`
+      updated per repo convention.
+
+## 8. Open Questions for Tech Lead RFC
+
+- Exact conflict/versioning mechanism for EC-2.
+- Whether invitations are party-scoped or bound to an invited email.
+- Session/token expiry policy for AC-1.3.
+- Local stand-ins for Lambda/S3/DB per NFR-4.

--- a/docs/multi-user-sync/RFC.md
+++ b/docs/multi-user-sync/RFC.md
@@ -1,0 +1,370 @@
+# RFC: Multi-User Sync — Architecture
+
+Status: Proposed
+Author: Tech Lead
+Inputs: `feature-brief.md` (binding), `PRD.md` (AC/EC numbering used below),
+`DESIGN.md` (approved UX), `CLAUDE.md` (repo rules).
+Companion: `TASKS.md` (PR breakdown).
+
+## 1. System overview
+
+Three pieces, deliberately few:
+
+1. **Frontend (this repo).** `localStorage` stays the runtime source of
+   truth and `STORAGE_TYPES.LOCAL` stays the app-data storage. Sync is a
+   new, additive path: a small typed HTTP client (`src/services/syncApi/`),
+   a new Redux slice (`src/redux/syncManager/`), the DESIGN.md screens, and
+   a pure merge engine (`src/helpers/syncMergeHelper/`).
+2. **Sync backend: one small HTTP service.** ~10 JSON endpoints (auth,
+   party, invitations, backup GET/PUT with compare-and-swap). The handler
+   core is framework-free plain Node (`server/core/`) with a pluggable
+   storage interface, wrapped by two adapters:
+   - `server/index.js` — local dev server (`node:http`, on-disk JSON under
+     `server/.data/`, gitignored). Zero runtime dependencies. This is the
+     mandatory local implementation (NFR-4).
+   - `server/lambda.js` — AWS Lambda Function URL adapter with S3 storage
+     (written when we deploy; same core, same contract).
+3. **Production infra: 1 Lambda + 1 S3 bucket. No database.**
+
+### Why this infra (cost notes)
+
+- The brief suggests Lambda + S3 + MongoDB. The only thing the DB would
+  hold is a handful of user/party/invitation records for one family. S3
+  stores small JSON objects perfectly well, and since S3 now supports
+  conditional writes (`If-Match`/`If-None-Match` on PUT) it also gives us
+  the compare-and-swap we need for EC-2 — the DB adds a third moving part,
+  a connection secret, and (Atlas) an external vendor, for zero benefit at
+  this scale. **Rejected.**
+- Lambda **Function URL** instead of API Gateway: Function URLs are free,
+  support CORS natively, and we need no throttling/custom domains.
+- Expected cost at family scale (≤10 users, manual syncs): a few hundred
+  Lambda invocations and a few MB of S3 per month — effectively **$0**
+  (well inside the always-free tiers; worst case pennies).
+- Everything the cloud does, the local server does with the same core code
+  and an on-disk storage adapter, so dev/test/CI never touch AWS.
+
+### Dormant auth code: build new, leave it alone
+
+`RemoteStorage`, `AuthenticatedApp`, `PrivateRoute`, `Lobby`, and the
+`userManager` action creators all target the defunct `expenses-manager-api`
+(cookie sessions, `sessionStorage`, app-gating). Our auth is optional and
+additive (AC-1.7), token-based, and must not gate anything. Reusing that
+code means fighting its assumptions; we reuse only what DESIGN.md already
+chose: `SignIn`/`SignUp`'s `FormValidation`/`FormModel` logic and the
+`Forms.js` inputs. The dormant files are **not modified and not deleted**
+(their GitHub issues still track them). New Redux state goes in a new
+`syncManager` slice, not `userManager`.
+
+## 2. Data model
+
+### 2.1 Server-side (S3 objects in prod / JSON files under `server/.data/`)
+
+```
+users/{sha256(lowercased email)}.json
+  { id, email, firstName, lastName,
+    password: { algo: "scrypt", N, r, p, saltB64, hashB64 },
+    partyId: string | null, createdAt }
+
+parties/{partyId}.json
+  { id, name,                       // "{organizer first name}'s Party"
+    organizerId,
+    members: [ { id, firstName, lastName, email, blocked: boolean } ],
+    canceled: boolean,
+    invitations: { [sha256(code)]: <AES-256-GCM ciphertext, base64> },
+    createdAt }
+
+parties/{partyId}.backup.json
+  { uploadedBy, uploadedAt, envelope }   // envelope: see 2.3
+```
+
+- An invitation plaintext record (never stored unencrypted):
+  `{ password: {scrypt fields}, used: boolean, createdBy, createdAt }`.
+  Lookup is by hash of the code; the record itself is encrypted (AC-2.4).
+- **Version for CAS:** every read of `*.backup.json` returns an opaque
+  `version` string — the S3 ETag in prod, a monotonically increasing
+  integer serialized as a string in the local server. `parties/{id}.json`
+  updates (join/block/cancel/invite/redeem) use the same CAS internally
+  with one retry; collisions are ~impossible at family scale.
+
+### 2.2 Client-side (new localStorage keys, prefixed to avoid collisions)
+
+```
+sync.session  { token, user: { id, email, firstName, lastName } }
+sync.state    { partyId, lastSyncedVersion: string | null,
+                lastSyncedAt: number | null,
+                rejections: { [itemKey]: string[] /* content hashes */ } }
+```
+
+- `sync.session` present ⇔ logged in (AC-1.3: survives reload/restart;
+  cleared on logout, AC-1.4). Party membership/blocked/canceled state is
+  **not** cached as authoritative — `GET /me` refreshes it on app load and
+  after every sync-related server rejection (DESIGN 4.2 stale-state rule).
+- `rejections` is the permanent AC-3.9 memory (see §4). It only grows when
+  an upload **completes** (PM handoff: abandoned reviews leave no trace).
+- Known, accepted consequence: "Clear all data" calls `localStorage.clear()`
+  and therefore also signs the user out and forgets rejections. That is
+  consistent with its "danger zone" contract; documented, not special-cased.
+
+### 2.3 Backup envelope & attribution
+
+Sync reuses the exact `buildBackupEnvelope` shape
+(`{app, schemaVersion, exportedAt, data: {balance, buckets, categories,
+fixedEntries}}`) and validates downloads with the existing
+`parseBackupEnvelope` (which preserves unknown fields inside the arrays).
+One additive, optional field appears on syncable items, stamped **at
+creation time when a session exists** (AC-1.6):
+
+- balance entry: `{ id, amount, description, type, date, categories_path,
+  addedBy?: { id, name } }`
+- fixed-entry history state: `{ from, ..., addedBy? }`
+- bucket history state: `{ from, limit, addedBy? }`
+
+`name` is the first name, denormalized so the wizard renders "Added by
+Tom" with no lookup. Stamping happens in the **action creators** (via a
+tiny `src/services/session.ts` reader) — `LocalStorage` stays a dumb store
+and simply persists whatever fields the entry carries. Legacy/unattributed
+items (including everything uploaded by EC-1's first sync) show
+**"Added anonymously"** in the wizard. We record creator only — the wizard
+copy is "Added by", per DESIGN 4.3.1; a `modifiedBy` audit trail is
+over-engineering for a family app (see §9).
+
+## 3. HTTP API contract
+
+Shared verbatim by the local server and the future Lambda. JSON bodies;
+base URL from `REACT_APP_SYNC_API_HOST` (default `http://localhost:4000`;
+new var — the old `REACT_APP_API_HOST` stays owned by the dormant API).
+Auth: `Authorization: Bearer <token>` on everything except signup/login.
+Errors: `{ "error": { "code": "<CODE>", "message": "<human text>" } }`.
+
+| # | Endpoint | Auth | Request → Success | Errors |
+|---|---|---|---|---|
+| 1 | `POST /api/auth/signup` | – | `{email, password, firstName, lastName}` → `201 {token, user}` | 400 `VALIDATION_ERROR`; 409 `EMAIL_TAKEN` |
+| 2 | `POST /api/auth/login` | – | `{email, password}` → `200 {token, user}` | 401 `INVALID_CREDENTIALS` (same body whether email exists or not, AC-1.5) |
+| 3 | `GET /api/me` | ✓ | → `200 {user, party}` where `party` = `null` or `{id, name, organizerId, canceled, youAreBlocked, members: [{id, firstName, lastName, email, blocked}]}` | 401 `UNAUTHORIZED` |
+| 4 | `POST /api/party` | ✓ | `{}` → `201 {party}` (name auto: "{firstName}'s Party") | 409 `ALREADY_IN_PARTY` |
+| 5 | `POST /api/party/invitations` | ✓ org | `{password}` → `201 {code}` (e.g. `K7X9-QP2M`; returned once, never again) | 403 `NOT_ORGANIZER`; 404 `NO_PARTY`; 410 `PARTY_CANCELED` |
+| 6 | `POST /api/party/join` | ✓ | `{code, password}` → `200 {party}` | 404 `INVITATION_NOT_FOUND`; 401 `INVITATION_WRONG_PASSWORD` (EC-7, not consumed); 410 `INVITATION_USED` (EC-8) or `PARTY_CANCELED`; 409 `ALREADY_IN_PARTY` (EC-6, not consumed) |
+| 7 | `POST /api/party/members/{userId}/block` | ✓ org | `{}` → `200 {party}` | 403 `NOT_ORGANIZER`; 404 `NO_PARTY` |
+| 8 | `POST /api/party/cancel` | ✓ org | `{}` → `200 {party}` | 403 `NOT_ORGANIZER`; 404 `NO_PARTY` |
+| 9 | `GET /api/party/backup` | ✓ | → `200 {version, envelope}` | 404 `NO_BACKUP` (EC-1) or `NO_PARTY`; 403 `BLOCKED` (EC-9); 410 `PARTY_CANCELED` |
+| 10 | `PUT /api/party/backup` | ✓ | `{baseVersion, envelope}` → `200 {version}` | 409 `VERSION_CONFLICT` (EC-2); 403 `BLOCKED`; 410 `PARTY_CANCELED`; 404 `NO_PARTY`; 400 `VALIDATION_ERROR` (bad/oversized envelope, limit 1 MB) |
+
+Notes:
+- `PUT` with `baseVersion: null` means "create only" (EC-1) — rejected with
+  `VERSION_CONFLICT` if a backup already exists. Otherwise the server
+  compares `baseVersion` to the current version (S3 `If-Match`/
+  `If-None-Match: *` in prod; integer compare locally) and swaps atomically.
+- Blocked/canceled are enforced **server-side on every backup call** (a
+  stale client can never download or upload, EC-9/AC-2.10); endpoints 9–10
+  are also what re-surface these states to the client mid-review.
+- Logout is client-side only (delete `sync.session`); tokens are stateless.
+  Server-side revocation isn't needed: the damaging capabilities (sync)
+  are re-checked against party state per request.
+- The server treats `envelope` as an opaque blob apart from size/JSON/app-id
+  checks — all merge intelligence lives in the client.
+
+## 4. Merge & idempotency algorithm (the heart)
+
+All pure functions in `src/helpers/syncMergeHelper/` (TS, fully
+unit-testable, no I/O).
+
+### 4.1 Item identity and change detection
+
+Every syncable unit gets an **itemKey** and a **contentHash**:
+
+| Kind | itemKey | Payload hashed |
+|---|---|---|
+| Entry | `entry:{id}` | whole entry minus `id` |
+| Fixed-entry history state | `fixed:{id}:{from}` | that history state minus `from` |
+| Bucket history state | `bucket:{lowercased name}:{from}` | that state minus `from` |
+
+`contentHash` = FNV-1a over a canonical JSON serialization (recursively
+sorted keys). It detects change, it is not security — no crypto needed, so
+it runs identically in jsdom.
+
+- Fixed entries and buckets are diffed **per history state** (their arrays
+  are already append-mostly, keyed by `from`), so "Tom raised the Groceries
+  bucket for August" is one reviewable item. Removal tombstones
+  (`{from, removed: true}`) are states like any other and sync the same way.
+- A brand-new fixed entry / bucket arrives as its full set of states but is
+  presented as **one wizard card** (its resolved current state); its
+  decision applies to all its pending states.
+- An **edit** to an existing entry by another member = same itemKey,
+  different contentHash → presented as a "changed" item; Accept replaces
+  the local value. Because rejections are remembered per
+  `(itemKey, contentHash)`, rejecting one edit does not suppress a *later,
+  different* edit — and EC-5's modified value (new hash) is seen as current
+  by the next syncer.
+
+### 4.2 Diff (on download)
+
+```
+incoming = []
+for each remote item (entry / fixed state / bucket state):
+  key, hash = identity(item)
+  if local has key with equal hash        → skip  (already applied / own)
+  if sync.state.rejections[key] ∋ hash    → skip  (AC-3.9 / EC-4)
+  else → incoming += { key, hash, item, isChange: local has key }
+```
+
+Diffing is **additive-only**: a remote backup *lacking* a local item never
+deletes anything locally (deletion sync is out of scope, per PRD §6; a
+locally deleted entry that still exists remotely will re-appear as
+incoming once — rejecting it then suppresses it permanently).
+
+### 4.3 Sync flow (state machine)
+
+1. `GET /api/party/backup`.
+   - `403/410` → DESIGN 4.2 blocked/canceled banners, refresh `/me`, stop.
+   - Network failure → "Couldn't reach your party…", stop (AC-3.11).
+   - `404 NO_BACKUP` (EC-1) → `PUT` local snapshot with `baseVersion: null`
+     → first-sync confirmation. Wizard skipped. Never an error.
+2. Validate with `parseBackupEnvelope`; run the diff (4.2).
+3. `incoming` empty:
+   - local snapshot content-equals `envelope.data` → **"You're up to
+     date."** No upload (AC-3.3).
+   - otherwise (local-only additions) → skip wizard, `PUT` merged local
+     snapshot with `baseVersion = downloaded version`, then "You're up to
+     date." On 409 → restart from step 1.
+4. `incoming` non-empty → route to `/sync-review`. **All decisions are
+   staged in wizard component state only** (DESIGN 4.3 staging model);
+   nothing touches `localStorage` yet. Abandonment (cancel, navigation,
+   crash) therefore discards everything, including rejections
+   (PM handoff on AC-3.9).
+5. Review completes → build `merged` **in memory**: local snapshot + each
+   accepted item applied (entries appended/replaced by id; fixed/bucket
+   states upserted by `from`, histories re-sorted; modified items use the
+   edited values, EC-5). Rejected items are simply not applied — and hence
+   absent from the uploaded snapshot; the contributor keeps them locally
+   (additive diffing) so nothing is silently lost.
+6. `PUT {baseVersion: downloaded version, envelope: wrap(merged)}`.
+   - `200 {version}` → **commit**: write `merged` to `localStorage`,
+     record rejections `(key, hash)` into `sync.state.rejections`, set
+     `lastSyncedVersion/At`, re-dispatch `getBalance`/buckets/fixed
+     loaders, show success screen.
+   - `409 VERSION_CONFLICT` (EC-2) → staged decisions **discarded**, offer
+     "Sync again" (fresh download → fresh wizard), per DESIGN 4.3.4. No
+     replay of stale decisions: they may reference items another member
+     just modified.
+   - `403/410` → discard, return to `/data-management`, DESIGN 4.2 banner.
+   - Network failure → stay on summary with Retry, same staged set,
+     local data untouched (AC-3.11/EC-3 — nothing was committed).
+
+The commit in step 6 is the **only** write to app `localStorage` in the
+whole flow, which makes AC-3.11, mid-wizard cancel, and EC-2 the same
+one-line guarantee.
+
+## 5. Security design
+
+- **Passwords (AC-1.2):** hashed with Node's built-in `crypto.scrypt`
+  (N=16384, r=8, p=1, 16-byte random salt), compared with
+  `crypto.timingSafeEqual`. Plaintext exists only inside the TLS request
+  body; never logged, never in URLs.
+- **Login errors (AC-1.5):** identical 401 body for unknown email and
+  wrong password.
+- **Invitations (AC-2.4/NFR-2):** the code is 8 random base32 chars
+  (crypto RNG, shown once, `XXXX-XXXX`); stored only as `sha256(code)`
+  lookup key plus an AES-256-GCM-encrypted record (random 12-byte IV per
+  record, server `ENCRYPTION_KEY`, 32 bytes) containing the scrypt-hashed
+  invite password and the `used` flag. Wrong password ≠ consumed (EC-7);
+  redemption flips `used` under CAS so it is single-use even under a race
+  (EC-8). Code and password travel only in POST bodies over TLS.
+- **API auth tokens:** compact HMAC-SHA256-signed token (JWT-style:
+  `base64url(payload).base64url(sig)`, payload `{sub, iat, exp}`), signed
+  with server `TOKEN_SECRET`, 30-day expiry (AC-1.3; on 401 the client
+  clears the session and shows logged-out state). No refresh rotation, no
+  MFA, no OAuth — deliberately (AC-1.1).
+- Token lives in `localStorage` (needed for AC-1.3 persistence). XSS is the
+  accepted residual risk — same trust level as the financial data already
+  in `localStorage`; the token grants nothing beyond that same party data.
+- Transport: prod = HTTPS (Function URLs are TLS-only). Local dev =
+  `http://localhost`, loopback-only; acceptable stand-in for "in transit"
+  in a dev environment.
+- Non-goals (documented, not accidental): rate limiting, account lockout,
+  email verification, server-side token revocation — wrong cost/benefit
+  for a family app; invitation security already stacks two secrets.
+
+## 6. Local dev story (NFR-4)
+
+```
+Terminal 1:  npm run sync-server     # node server/index.js  → :4000
+Terminal 2:  npm start               # CRA dev server        → :3000
+```
+
+- `server/` is plain Node (no deps, no build step): `core/` (handlers,
+  crypto, storage interface), `storage-fs.js` (JSON files in
+  `server/.data/`, gitignored), `index.js` (`node:http` adapter, CORS for
+  localhost:3000).
+- `.env.template` gains `REACT_APP_SYNC_API_HOST=` (defaults to
+  `http://localhost:4000` in `src/config.js`).
+- Secrets default to dev values in local mode (`TOKEN_SECRET`,
+  `ENCRYPTION_KEY` env vars override).
+- Reset the world: delete `server/.data/`. Multi-user testing: two browser
+  profiles (or one normal + one private window) against the same server.
+- Server tests: `npm run test:server` → `node --test server/` (built-in
+  runner; CRA's jest doesn't scan outside `src/`, and we don't fight it).
+- `server/README.md` documents all of the above plus the cloud steps (§7).
+
+## 7. Real-cloud deployment (outline; full steps in `server/README.md`)
+
+1. Create S3 bucket (private, default encryption; enable bucket versioning
+   as a free safety net for backup objects).
+2. Create Lambda (Node 20), upload `server/` with `lambda.js` as handler
+   (Function-URL event ↔ core adapter; `storage-s3.js` implements the same
+   storage interface via `GetObject`/`PutObject` with
+   `If-Match`/`If-None-Match` for CAS).
+3. IAM role: `s3:GetObject/PutObject/ListBucket` scoped to the bucket.
+4. Env vars: `BUCKET`, `TOKEN_SECRET`, `ENCRYPTION_KEY` (32 random bytes).
+5. Enable Function URL, auth type NONE, CORS restricted to the app origin.
+6. Build the frontend with `REACT_APP_SYNC_API_HOST=<function URL>`; host
+   statically as today. No other infra.
+
+## 8. Testing strategy
+
+- **Merge engine:** exhaustive jest unit tests on the pure functions
+  (identity, hashing, diff, apply, rejection memory) — this is where EC
+  combinatorics are cheap.
+- **Frontend integration tests (NFR-5, network-free):** new helper
+  `src/integrationTests/helpers/fakeSyncServer.ts` — an in-memory
+  implementation of the §3 contract installed as a `window.fetch` stub for
+  the `REACT_APP_SYNC_API_HOST` base URL. It exposes test seams:
+  `seedUser`, `seedPartyWithMembers`, `seedRemoteBackup(envelope)`,
+  `loginAs(email)` (pre-writes `sync.session`), `failNext("GET /api/party/backup")`,
+  `getUploadedBackups()`. Tests drive everything through the UI
+  (`screen.findByText`, roles) per repo rules; the fake lets one test act
+  as two family members (seed a remote backup "uploaded by Tom", then sync
+  as Jane). Contract drift between fake and `server/core` is bounded by
+  both being generated from §3 and by shared error-code constants
+  (`src/services/syncApi/contract.ts`; the dep-free server duplicates the
+  ~20 lines deliberately — RFC §3 is the source of truth).
+- **Server:** `node --test` contract tests against `core/` with in-memory
+  storage (signup/login, invitation lifecycle EC-6/7/8, CAS conflict,
+  blocked/canceled enforcement).
+- **Regression:** existing integration tests run untouched on every PR
+  (NFR-3); `npm run typecheck` and `npm run lint` gate every PR.
+
+## 9. Rejected alternatives
+
+- **Lambda + S3 + MongoDB (brief's suggestion):** the DB would hold ~10 tiny
+  records; S3 conditional writes already give CAS. Third service, connection
+  secrets, no benefit.
+- **DynamoDB for users/invitations:** still a second service and a second
+  local stand-in to maintain; S3 JSON objects with CAS suffice at this scale.
+- **Firebase/Supabase/Amplify:** vendor lock-in and much harder "full local
+  implementation" story than 300 lines of plain Node.
+- **Append-only backup history reconciled on download (EC-2 option B):**
+  more storage, unbounded growth, complex replay logic; CAS + "sync again"
+  re-review is simpler and the discarded work is seconds at family scale.
+- **Reusing `RemoteStorage`/`AuthenticatedApp`/`userManager`:** built for a
+  defunct cookie-session API that gates the whole app; contradicts AC-1.7.
+  Reused instead: form-validation logic and form components (per DESIGN).
+- **Carrying staged decisions across an EC-2 conflict:** could silently
+  accept values a member just changed — the exact loss EC-2 forbids
+  (rationale in DESIGN 4.3.4).
+- **Cookie sessions:** cross-origin (Function URL ≠ app origin) means
+  SameSite/CSRF machinery; a bearer token is simpler and sufficient.
+- **`modifiedBy` audit trail / per-field merge:** wizard only needs "added
+  by" (AC-3.4, DESIGN); anything more is over-engineering.
+- **Client-side end-to-end encryption of backups:** would hide data from
+  the server but breaks nothing we need; key distribution inside a family
+  via invitation flow would dwarf the feature. Out of scope.

--- a/docs/multi-user-sync/TASKS.md
+++ b/docs/multi-user-sync/TASKS.md
@@ -1,0 +1,230 @@
+# Multi-User Sync — PR Breakdown
+
+Six stacked PRs, based on and merged into `sync` (never `master`). Every
+PR leaves the app green — `npm test -- --testPathPattern="integrationTests"`
+(existing tests unmodified, NFR-3), `npm run typecheck`, `npm run lint` —
+and makes the version bump + `CHANGELOG.md` entry listed per PR. New
+frontend code is TS where practical; server code is dep-free plain Node.
+AC/EC refs → `PRD.md`; screens/copy → `DESIGN.md`; architecture → `RFC.md`.
+
+---
+
+## PR 1 — Accounts: local sync server (auth), API client, account UI, attribution
+
+**Goal:** a user can sign up, log in/out, and stay logged in across
+reloads; entries created while logged in are attributed; nothing changes
+for logged-out users.
+
+**Scope**
+- `server/`: `core/` (router, HMAC token sign/verify, scrypt, storage
+  interface), `storage-fs.js`, `index.js` (`node:http` + CORS), RFC §3
+  endpoints 1–3 (`/api/me` returns `party: null` for now), README (local
+  run), `npm run sync-server` / `test:server` scripts, gitignored `.data/`.
+- `src/services/syncApi/` (+`contract.ts` error codes), `src/services/
+  session.ts`, `src/redux/syncManager/` slice, `REACT_APP_SYNC_API_HOST`
+  in `src/config.js` + `.env.template`.
+- UI (DESIGN §2): header account chip, routes `/account`, `/sign-up`,
+  `/sign-in` in `Dashboard`'s `<Switch>` — reuse `FormValidation`/
+  `Forms.js` in `MainContentContainer`; dormant `SignIn`/`SignUp`/
+  `NoSessionContainer` files untouched.
+- Attribution (AC-1.6, RFC §2.3): stamp `addedBy` in `expensesManager`
+  action creators (entry / fixed-entry / bucket writes) when logged in.
+- `src/integrationTests/helpers/fakeSyncServer.ts` (auth portion);
+  `renderApp` accepts an optional logged-in session.
+
+**Out of scope:** parties, invitations, sync, any Data Management change.
+
+**Acceptance criteria:** AC-1.1–1.7 (sync UI itself doesn't exist yet, so
+AC-1.4/1.7's "sync disabled" reduces to: no sync affordance anywhere).
+
+**Tests**
+- `node --test`: signup/login contract, duplicate email, generic
+  wrong-credential body, token expiry.
+- New `accounts.test.tsx`: signup→logged-in chip; duplicate-email and
+  wrong-password errors (role=alert, generic copy); session survives a
+  re-`renderApp` (reload analogue); logout shows "Signed out…" status;
+  logged-out app renders all existing screens unchanged.
+
+**Depends on:** — (first PR on `sync`).
+**Version:** 1.2.0.
+
+---
+
+## PR 2 — Parties: create, invite, join
+
+**Goal:** an organizer creates a party and generates an invitation
+(token + organizer-chosen password); an invitee redeems it exactly once.
+
+**Scope**
+- `server/core`: party + invitation endpoints (RFC §3, 4–6), AES-256-GCM
+  invitation records, sha256(code) lookup, CAS on `parties/{id}.json`;
+  `/api/me` now returns the party.
+- Client: `syncApi`/`syncManager` party support; screens `/party`
+  (no-party, member, organizer + member list), `/party/invite` (2-step,
+  copy buttons, DESIGN 3.4), `/party/join` (DESIGN 3.5, EC-6/7/8 copy);
+  organizer-only controls hidden for members (AC-2.12); "Add a member"
+  routes to the invite flow (AC-2.8 = invite, per PM handoff).
+- `fakeSyncServer`: party/invitations + `seedPartyWithMembers`.
+
+**Out of scope:** block/cancel (PR 3), sync card/wizard.
+
+**Acceptance criteria:** AC-2.1–2.8, EC-6, EC-7, EC-8.
+
+**Tests**
+- `node --test`: invitation lifecycle — wrong password not consumed,
+  redeem once, second redeem `INVITATION_USED`, already-in-party rejected
+  without consuming, no plaintext code/password in stored files.
+- New `party.test.tsx`: create party via confirm → organizer view named
+  "{Name}'s Party"; generate invitation → code+password shown with
+  "Copied" live text; member cannot see organizer controls.
+- New `partyJoin.test.tsx`: redeem happy path → member view; wrong
+  password error then successful retry on the same code; reused-token
+  error.
+
+**Depends on:** PR 1.
+**Version:** 1.3.0.
+
+---
+
+## PR 3 — Party management: block & cancel
+
+**Goal:** the organizer can block members and cancel the party; those
+states render correctly for the affected users.
+
+**Scope**
+- `server/core`: block + cancel endpoints (§3.7–3.8); `BLOCKED` /
+  `PARTY_CANCELED` enforcement on the (not-yet-used) backup endpoints so
+  PR 4 inherits it.
+- Client: Block button + confirm on `MemberRow`, Cancel party + confirm
+  (DESIGN 3.2); blocked/canceled `/party` views (DESIGN 3.6); `/me`
+  refresh drives `youAreBlocked`/`canceled`.
+- `fakeSyncServer`: block/cancel + state transitions.
+
+**Out of scope:** sync UI (the blocked/canceled *sync* messaging lands
+with the sync card in PR 4).
+
+**Acceptance criteria:** AC-2.9 (state part), AC-2.10, AC-2.12.
+
+**Tests**
+- `node --test`: blocked member 403 on backup GET/PUT; canceled party
+  410; non-organizer block/cancel → 403 `NOT_ORGANIZER`.
+- New `partyManagement.test.tsx`: block confirm → row shows "Blocked";
+  blocked user's `/party` shows removed-from-party view; cancel confirm →
+  organizer and member both see canceled view; member view has no
+  Block/Cancel controls.
+
+**Depends on:** PR 2.
+**Version:** 1.4.0.
+
+---
+
+## PR 4 — Sync engine + Data Management sync card (no-wizard paths)
+
+**Goal:** the merge engine exists and is fully unit-tested; the Sync card
+works end-to-end for every path that doesn't need the wizard.
+
+**Scope**
+- `src/helpers/syncMergeHelper/` (TS, pure): canonical hash, itemKey,
+  diff, apply, snapshot equality, rejection filtering (RFC §4.1–4.2).
+- `server/core` + `fakeSyncServer`: backup GET/PUT with `baseVersion` CAS
+  (§3.9–3.10), 1 MB limit.
+- Client: `sync.state` storage, sync thunk (RFC §4.3 steps 1–3 + 6's
+  commit), Sync card on `/data-management` (DESIGN §4.1–4.2): all five
+  disabled-state captions, Last synced caption, in-progress state,
+  "You're up to date.", EC-1 first-sync confirmation, download-failure
+  alert, blocked/canceled rejection banners + card re-render. With
+  incoming changes the thunk routes to `/sync-review`, shipped here as a
+  minimal "Review changes" placeholder offering only Cancel review
+  (discard-and-return, DESIGN's safe-abandonment rule) — nothing is ever
+  applied unreviewed.
+- Existing Download/Restore/Clear cards byte-identical (AC-3.7).
+
+**Out of scope:** item cards, accept/reject/modify, summary/upload (PR 5).
+
+**Acceptance criteria:** AC-2.11, AC-3.1, AC-3.2, AC-3.3, AC-3.7, AC-3.11
+(download side), EC-1, EC-9.
+
+**Tests**
+- Unit: syncMergeHelper (identity/hash/diff/apply incl. fixed-entry
+  tombstones, bucket case-insensitive keys, additive-only rule).
+- New `syncGating.test.tsx`: the five disabled/enabled caption states.
+- New `syncNoWizard.test.tsx`: EC-1 first sync uploads + confirmation;
+  identical states → "You're up to date.", no upload; local additions +
+  unchanged remote → silent upload then up-to-date; download failure
+  alert leaves existing entries rendering; blocked/canceled rejection
+  banners; cancel-from-placeholder changes nothing.
+- Existing `singleFileBackup.test.tsx` passes unmodified.
+
+**Depends on:** PR 3 (state enforcement), PR 1 (client/session).
+**Version:** 1.5.0.
+
+---
+
+## PR 5 — Review wizard: accept / reject / modify, staging, CAS upload
+
+**Goal:** the full DESIGN §4.3 wizard — the remaining heart of the feature.
+
+**Scope**
+- `/sync-review` (replaces PR 4 stub): `ReviewItemCard` (+attribution,
+  "Added anonymously" fallback), `WizardProgress`, Accept/Reject/Modify
+  (Modify reuses `Forms.js`/`CategorySelector`, adds `InputDate`),
+  Accept All / Reject All confirms, `WizardSummary`, staged-decision
+  model (component state only), commit-on-upload-success, retry on
+  failure, EC-2 conflict → discard + "Sync again", blocked/canceled
+  mid-review handling, rejection memory persisted only on completed
+  upload (AC-3.9 + PM handoff), focus management/aria per DESIGN §5.
+
+**Out of scope:** any server change (contract is finished).
+
+**Acceptance criteria:** AC-1.6 (display), AC-3.4, AC-3.5, AC-3.6, AC-3.8,
+AC-3.9, AC-3.10, AC-3.11 (upload side), EC-2, EC-3, EC-4, EC-5.
+
+**Tests** (all UI-driven via `fakeSyncServer` seeded as another member)
+- `syncWizard.test.tsx`: mixed entry/fixed/bucket incoming set shows
+  correct cards, counts, attribution (incl. anonymous fallback); accept →
+  visible in month view after finish; reject → absent; modify → edited
+  value visible and present in `getUploadedBackups()` (EC-5).
+- `syncWizardBulk.test.tsx`: Accept All / Reject All confirms + summary
+  counts (AC-3.5).
+- `syncIdempotency.test.tsx`: re-sync after completed review → "You're up
+  to date."; rejected item never re-shown (EC-4); abandoned review
+  re-presents everything next sync.
+- `syncConflict.test.tsx`: EC-2 mid-review version bump → conflict alert,
+  "Sync again" restarts fresh; upload network failure → error + Retry,
+  dashboard data unchanged (EC-3).
+
+**Depends on:** PR 4.
+**Version:** 1.6.0.
+
+---
+
+## PR 6 — Cloud deployment docs + DoD hardening sweep
+
+**Goal:** ship the "configure real third-party services" documentation and
+close every remaining PRD Definition-of-Done checkbox.
+
+**Scope**
+- `server/README.md`: full AWS steps (RFC §7 expanded — bucket, Lambda,
+  IAM, env vars, CORS, frontend build config) plus secret generation.
+  Adds `server/lambda.js` (Function-URL adapter) and `server/storage-s3.js`
+  (dep-free; not exercised by CI, documented as such).
+- Sweep: audit that no token/password plaintext appears in logs, storage
+  or payloads (grep + targeted `node --test` assertions); a11y pass on
+  new screens (focus rings, aria-labels per DESIGN §5); CHANGELOG
+  consolidation for the feature.
+
+**Out of scope:** new user-facing behavior.
+
+**Acceptance criteria:** NFR-1–NFR-5 closure; every PRD §7 DoD checkbox
+verified and mapped to a test from PRs 1–5 (add any found missing).
+
+**Tests:** only gap-fills discovered by the DoD audit.
+
+**Depends on:** PR 5.
+**Version:** 1.6.1.
+
+---
+
+**Cumulative DoD coverage:** accounts (PR 1), invitations/join (PR 2),
+block/cancel (PR 3), gating + EC-1/up-to-date/failed-download (PR 4),
+wizard/idempotency/EC-2/3/4/5 (PR 5), docs + NFR audit (PR 6).

--- a/docs/multi-user-sync/TEST-PLAN.md
+++ b/docs/multi-user-sync/TEST-PLAN.md
@@ -1,0 +1,413 @@
+# Test Plan: Multi-User Sync
+
+Inputs: `PRD.md` (AC/EC), `DESIGN.md` (screens/copy/a11y), `RFC.md`
+(architecture/contract), `TASKS.md` (PR breakdown), `CLAUDE.md`.
+
+IDs: `SC-<PR>.<n>` server contract (`node --test`), `UT-4.<n>` merge-engine
+unit tests, `TC-<PR>.<n>` frontend integration tests, `MX-<n>` manual.
+**[QA]** = not promised by `TASKS.md`; added here as a sign-off condition,
+with a one-line reason.
+
+---
+
+## 1. Test strategy
+
+**(a) Server contract** — `npm run test:server` (`node --test server/`,
+zero deps). Calls `server/core` directly: status/error-code/body, plus
+reading `server/.data/*.json` for secrets-at-rest checks.
+
+**(b) Frontend integration** — `npm test --
+--testPathPattern="integrationTests"` (jsdom, `renderApp`). All sync
+fetches route through `fakeSyncServer.ts` stubbing `window.fetch`; no live
+network. Assertions use `screen.findByText`/`getByRole` (NFR-5,
+`CLAUDE.md`), never Redux/`localStorage` reads — except the one pattern
+`singleFileBackup.test.tsx` already sets as precedent: reading
+`localStorage` only to prove a **failure path wrote nothing**, never to
+assert success (see TC-1.7).
+
+**(c) Manual exploratory** — two terminals (`npm run sync-server` +
+`npm start`), two browser profiles as two family members. Run after PR5
+and again after PR6. Covers what jsdom can't: real browser-restart
+persistence, a genuine two-tab CAS race, real disconnection, real
+`server/index.js` HTTP/CORS, plaintext-at-rest inspection on disk. §6.
+
+---
+
+## 2. Traceability matrix
+
+| AC/EC | Covered by | Gap |
+|---|---|---|
+| AC-1.1 | SC-1.1, SC-1.4, TC-1.1 | |
+| AC-1.2 (pw never plaintext) | SC-1.8 **[QA]** | PR1's promised tests never check storage format; only PR6's grep sweep would. Added at the source PR. |
+| AC-1.3 (persists reload/restart) | TC-1.4; MX-2 real restart | |
+| AC-1.4 (logout) | TC-1.5, TC-4.1 | |
+| AC-1.5 (dup email / wrong creds, generic) | SC-1.2, SC-1.5, SC-1.6, TC-1.2, TC-1.3 | |
+| AC-1.6 (attribution) | TC-5.1 | Stamping happens in PR1 but is first checked in PR5's wizard — a PR1 stamping bug ships undetected for 4 PRs. Added TC-1.7. |
+| AC-1.7 (logged-out unaffected) | TC-1.6, TC-4.1, §4 | |
+| AC-2.1 (create one party) | TC-2.1 | |
+| AC-2.2 (≤1 party; UI never offers 2nd) | TC-2.9 **[QA]** | No PR2 test asserts CTAs are absent for an existing member. |
+| AC-2.3 (generate invite) | TC-2.3, SC-2.3 | |
+| AC-2.4 (invite encrypted) | SC-2.9 | |
+| AC-2.5 / EC-7 (wrong pw, not burned) | SC-2.6, TC-2.6 | |
+| AC-2.6 / EC-8 (reused token) | SC-2.7, TC-2.7 | |
+| AC-2.7 / EC-6 (already in party) | SC-2.8, TC-2.8 **[QA]** | DESIGN calls this path "normally unreachable"; no promised UI test. |
+| AC-2.8 (direct add = invite) | TC-2.3 | |
+| AC-2.9 (block; not retroactive) | SC-3.1, TC-3.1 mechanics; TC-3.6 **[QA]** non-retroactivity | "Entries already contributed stay in history" needs a synced backup, so it can't be closed until PR5 lands — flag for PR5 sign-off, not just PR3. |
+| AC-2.10 (cancel; no data touched) | SC-3.5, TC-3.3, TC-3.4 | |
+| AC-2.11 (sync gated) | TC-4.1 | |
+| AC-2.12 (organizer-only controls) | TC-2.4, TC-3.5 | |
+| AC-3.1 (manual only) | TC-4.10 **[QA]** | No promised test proves *absence* of an automatic sync call. |
+| AC-3.2 (download + diff) | TC-4.4, TC-4.5, TC-5.1 | |
+| AC-3.3 / EC-1 | TC-4.3, TC-4.4 | |
+| AC-3.4 (wizard content/attribution/3 actions) | TC-5.1–5.4 | |
+| AC-3.5 (Accept/Reject All) | TC-5.6, TC-5.7 | |
+| AC-3.6 (accept/reject/modify) | TC-5.2–5.5 | |
+| AC-3.7 (Restore unmodified) | TC-4.11, §4 | |
+| AC-3.8 (result becomes new backup) | TC-5.9, TC-5.4 | |
+| AC-3.9 / EC-4 (idempotent) | TC-5.13, TC-5.14 | |
+| AC-3.10 (entries+fixed+buckets) | TC-5.1 | |
+| AC-3.11 / EC-3 (failed dl/upload untouched) | TC-4.6, TC-5.10 | |
+| EC-2 (version conflict) | TC-5.11 | |
+| EC-5 (modify value wins) | TC-5.4 | |
+| EC-9 (blocked sync rejected) | TC-4.7, TC-5.12, SC-3.3, SC-3.4 | |
+
+Cross-cutting gaps not tied to a single AC:
+- **No client-side test for token-expiry handling** (RFC §5: 401 → client
+  clears session, shows logged-out state). SC-1.7 is server-only. Added
+  TC-1.11.
+- PR6's "a11y pass" / "no plaintext" sweep is a manual audit in
+  `TASKS.md`, not new automated coverage — PR6 sign-off is contingent on
+  the checklists in §5/§6, not on test count alone.
+
+---
+
+## 3. Test cases
+
+### PR 1 — Accounts
+
+- **SC-1.1** Valid signup → `201 {token,user}`.
+- **SC-1.2** Signup with a taken email → `409 EMAIL_TAKEN`.
+- **SC-1.3** Signup missing password → `400 VALIDATION_ERROR`.
+- **SC-1.4** Valid login → `200 {token,user}`.
+- **SC-1.5** Correct email, wrong password → `401 INVALID_CREDENTIALS`.
+- **SC-1.6** Unregistered email → `401 INVALID_CREDENTIALS`, body
+  byte-identical in shape to SC-1.5 (no account-enumeration signal).
+- **SC-1.7** Expired token on `GET /api/me` → `401 UNAUTHORIZED`.
+- **SC-1.8 [QA]** Read `server/.data/users/<hash>.json` after signup: no
+  field equals the plaintext password; `password.algo === "scrypt"` with
+  non-empty salt/hash.
+
+- **TC-1.1** Sign up from `/account` (logged out) → header icon becomes
+  an initials chip; `/account` shows name/email.
+- **TC-1.2** Sign up with an email that already has an account →
+  `role="alert"` *"An account with this email already exists. Try signing
+  in instead."* with a working `Sign in` link, fields retained.
+- **TC-1.3** Sign in, wrong password → `role="alert"` exactly *"Email or
+  password is incorrect."*
+- **TC-1.4** Sign up, then re-`renderApp()` (reload analogue) without
+  touching storage → still shows the initials chip.
+- **TC-1.5** Log out → no confirm dialog; logged-out `/account` renders;
+  transient `role="status"` *"Signed out. Your data stays on this
+  device."*
+- **TC-1.6** Logged out, visit every existing route → unchanged from
+  today; header `aria-label="Account"`; zero sync DOM anywhere.
+- **TC-1.7 [QA]** *Gap-fill, AC-1.6.* Logged in as Jane, add an income.
+  No PR1 UI surfaces attribution yet, so — per the one sanctioned
+  exception in §1(b) — read `localStorage.getItem("balance")` and assert
+  the new entry's `addedBy.name === "Jane"`; comment inline why (PR5's
+  TC-5.1 is the later UI-level confirmation).
+- **TC-1.8** Submit sign-up/sign-in with a delayed `fakeSyncServer`
+  response → button reads "Signing up…"/"Signing in…", `disabled`.
+- **TC-1.9** `/sign-up` → `Cancel` → back to `/account`, no account
+  created.
+- **TC-1.10** Logged in → header `aria-label="Account: Jane Doe"`.
+- **TC-1.11 [QA]** *Gap-fill, token expiry.* Logged in;
+  `fakeSyncServer` returns `401` on the next authenticated call →
+  triggering it falls back to the logged-out view, no crash/stuck spinner.
+
+### PR 2 — Parties
+
+- **SC-2.1** `POST /api/party` (no existing party) → `201`, name =
+  `"{firstName}'s Party"`.
+- **SC-2.2** `POST /api/party` for a user already in one → `409
+  ALREADY_IN_PARTY`.
+- **SC-2.3** Organizer generates invitation → `201 {code}` shaped
+  `XXXX-XXXX`.
+- **SC-2.4** Non-organizer calls invitation endpoint → `403
+  NOT_ORGANIZER`.
+- **SC-2.5** Redeem correct code+password → `200`, member added.
+- **SC-2.6** Redeem correct code, wrong password → `401
+  INVITATION_WRONG_PASSWORD`; retry with correct password on the *same*
+  code still succeeds (EC-7, not burned).
+- **SC-2.7** Redeem an already-used code (either password) → `410
+  INVITATION_USED` (EC-8).
+- **SC-2.8** User already in party A redeems a code for party B → `409
+  ALREADY_IN_PARTY`; a later fresh user on the *same* code still succeeds
+  (proves it wasn't consumed, EC-6).
+- **SC-2.9** Inspect `server/.data/parties/*.json` after SC-2.3: code and
+  password appear nowhere in plaintext.
+
+- **TC-2.1** `Create a party` → confirm dialog *"Create a party? You'll
+  become its organizer and can invite family members."* → organizer card
+  `"Jane's Party"` with `Organizer` badge.
+- **TC-2.2 [QA]** `Create a party` → dismiss the confirm → still on
+  no-party view.
+- **TC-2.3** Organizer: `Add a member` → set password → `Generate
+  invitation` → code+password shown read-only with `Copy` buttons;
+  `Copy` shows *"Copied"* in an `aria-live="polite"` region (~2s).
+- **TC-2.4** Non-organizer member on `/party` → no `Add a
+  member`/`Cancel party`; footer *"Only Jane, the organizer, can add or
+  remove members."*
+- **TC-2.5** `/party/join` with valid code+password → redirected to
+  `/party`, member view (3.3), new member's row visible.
+- **TC-2.6** Right code, wrong password → `role="alert"` exactly *"That
+  password doesn't match this invitation. Double-check it with whoever
+  invited you and try again."*; fields retained; correcting and
+  resubmitting succeeds.
+- **TC-2.7** Redeem a code once, redeem again from a second account →
+  `role="alert"` exactly *"This invitation has already been used. Ask
+  the organizer to send you a new one."*
+- **TC-2.8 [QA]** Existing member force-navigated to `/party/join`
+  submits a valid code (stale-tab simulation) → `role="alert"` exactly
+  *"You already belong to a party. Refresh to see it."*
+- **TC-2.9 [QA]** *Gap-fill, AC-2.2.* Existing member visits `/party` →
+  no `Create a party`/`Join a party` CTA anywhere reachable.
+- **TC-2.10** Organizer, no members yet → list shows only Jane's row +
+  *"Invite family members to start syncing."*
+
+### PR 3 — Block & cancel
+
+- **SC-3.1** Organizer blocks a member → `200`, `blocked === true`.
+- **SC-3.2** Non-organizer block attempt → `403 NOT_ORGANIZER`.
+- **SC-3.3/3.4** Blocked member: `GET`/`PUT /api/party/backup` → `403
+  BLOCKED`.
+- **SC-3.5** Organizer cancels → `200`, `canceled === true`.
+- **SC-3.6** Non-organizer cancel attempt → `403 NOT_ORGANIZER`.
+- **SC-3.7** Canceled party: `GET`/`PUT /api/party/backup` → `410
+  PARTY_CANCELED`.
+
+- **TC-3.1** Organizer `Block`s Tom, confirms (*"Block Tom Doe? They'll
+  immediately lose the ability to sync. Entries they've already
+  contributed stay in the party's history."*) → Tom's row shows muted
+  `Blocked`, no `Block` button.
+- **TC-3.2** Tom (just blocked) loads `/party` → CTA layout, *"You've
+  been removed from this party by its organizer."*
+- **TC-3.3** Organizer `Cancel party`, confirms (*"Cancel Jane's Party?
+  No member will be able to sync afterward. Nobody's local data is
+  deleted."*) → organizer's own `/party` becomes canceled CTA view.
+- **TC-3.4** Member loads `/party` after cancel → *"Your party was
+  canceled. Create or join a new one to sync again."*
+- **TC-3.5** Member view has no `Block`/`Cancel party` controls, pre- and
+  post-cancel.
+- **TC-3.6 [QA]** *Gap-fill, AC-2.9 — run once PR5's sync exists, not at
+  PR3 merge.* Tom synced an entry, then got blocked; Jane syncs →
+  Tom's entry is still present as merged/incoming, not stripped.
+
+### PR 4 — Sync engine + Data Management card
+
+- **UT-4.1** `itemKey`/`contentHash` stable regardless of object key
+  order.
+- **UT-4.2** Local has `key` with equal `hash` → skipped (not incoming).
+- **UT-4.3** `(key,hash)` in `sync.state.rejections` → skipped even if
+  still in the remote backup (EC-4).
+- **UT-4.4** Same `key`, different `hash` → `isChange: true`.
+- **UT-4.5** Additive-only: item missing from remote is never removed
+  locally.
+- **UT-4.6** Bucket `itemKey` matching is case-insensitive.
+- **UT-4.7** `removed: true` tombstone diffed as an ordinary history
+  state.
+
+- **TC-4.1** Assert exact caption per state:
+  | State | Caption |
+  |---|---|
+  | Logged out | "Sign in and join a party to sync your entries across devices." |
+  | Logged in, no party | "Create or join a party to start syncing." |
+  | Party canceled | "Your party was canceled. Create or join a new one to sync again." |
+  | Blocked | "You've been removed from your party by its organizer. Sync is unavailable." |
+  | Enabled, never synced | "Never synced yet" |
+- **TC-4.2** Enabled, prior sync recorded → "Last synced: {relative
+  date}".
+- **TC-4.3** No remote backup yet (EC-1) → sync → no wizard;
+  `role="status"` *"This is the first sync for your party. Your data is
+  now the starting point — future syncs will compare against it."*;
+  `getUploadedBackups()` now has the local snapshot.
+- **TC-4.4** Remote content-equals local → `role="status"` *"You're up to
+  date."*; no `PUT` recorded.
+- **TC-4.5** Local-only additions, remote otherwise unchanged → no
+  wizard, silent `PUT`, then "You're up to date."
+- **TC-4.6** `failNext("GET /api/party/backup")` → `role="alert"*
+  *"Couldn't reach your party. Check your connection and try again."*;
+  button back to idle; existing entries still render.
+- **TC-4.7** GET rejected `403 BLOCKED` → `role="alert"` exactly *"This
+  sync was declined: you've been removed from your party by its
+  organizer. Nothing on this device was changed."*; card re-renders to
+  Blocked state (TC-4.1).
+- **TC-4.8** Same with `410 PARTY_CANCELED` → *"This sync was declined:
+  your party was canceled. Nothing on this device was changed."* → card
+  re-renders to Canceled state.
+- **TC-4.9** Mid-flight (delayed response) → "Syncing…" + spinner +
+  `disabled`; `aria-live="polite"` contains "Syncing with your party…".
+- **TC-4.10 [QA]** *Gap-fill, AC-3.1.* Render `/data-management`, click
+  nothing → `fakeSyncServer` records zero requests.
+- **TC-4.11** Existing `singleFileBackup.test.tsx` unmodified still
+  passes; additionally: Download/Restore controls unchanged in
+  count/order, Sync card sits between "Keep your data safe" and "Danger
+  zone" in DOM order.
+
+### PR 5 — Review wizard
+
+- **TC-5.1** Remote has a new entry (Tom), a changed fixed-entry state
+  (Sam), a new bucket state, and one entry with no `addedBy` (legacy) →
+  4 cards; correct kind badges; "Added by Tom"/"Added by Sam"; legacy
+  item shows *"Added anonymously"*; progress "Item 1 of 4".
+- **TC-5.2** `Accept` an expense, finish, upload → visible in its
+  month's Expenses view after `Done`.
+- **TC-5.3** `Reject` an income, finish, upload → absent everywhere
+  after `Done`.
+- **TC-5.4** `Modify` an expense (amount+description), `Save & accept`,
+  finish, upload → edited values (not original) shown on dashboard and
+  in `getUploadedBackups()`'s latest entry (EC-5).
+- **TC-5.5** `Modify`, edit, then `Cancel` → read-only card, no decision
+  recorded (progress count unchanged).
+- **TC-5.6** `Accept all` with N remaining → confirm text exactly
+  *"Accept the remaining N items without reviewing them individually?"*;
+  confirming jumps to summary, all N counted accepted.
+- **TC-5.7** `Reject all` → *"Reject the remaining N items without
+  reviewing them individually?"*
+- **TC-5.8** 8 accepted/1 modified/3 rejected → summary text exactly
+  *"8 accepted · 1 modified · 3 rejected"*.
+- **TC-5.9** `Upload & finish` success → "Saving…",
+  `aria-live="polite"` "Saving your changes…"; on completion
+  *"Synced! Your party is up to date."* + single `Done` → navigates to
+  `/data-management`.
+- **TC-5.10** `failNext("PUT /api/party/backup")` → stays on summary,
+  `role="alert"` *"Couldn't save your changes to your party. Check your
+  connection and try again."*; button becomes `Retry`; dashboard
+  unchanged; `Retry` re-attempts the same staged set without re-review.
+- **TC-5.11** Backup version bumped between download and upload (another
+  member synced) → `role="alert"` exactly *"Your party synced new
+  changes while you were reviewing. Sync again to pick them up — you'll
+  review everything fresh, including what you just saw."*; primary
+  becomes `Sync again` (discards staged, fresh download+wizard);
+  `Cancel review` still returns to `/data-management` untouched.
+- **TC-5.12** Mid-review, user blocked or party canceled so final `PUT`
+  is rejected → staged decisions discarded, lands on
+  `/data-management` with the matching TC-4.7/4.8 banner, not the
+  generic connection error.
+- **TC-5.13** Sync again right after a completed upload, nothing new →
+  "You're up to date.", no wizard.
+- **TC-5.14** An item rejected in a completed review; unrelated change
+  synced in by a third member; original user syncs again → the
+  rejected item never reappears/merges (EC-4), even though still in
+  party history.
+- **TC-5.15** Decide 2/5 items, navigate away via a bottom-tab link (no
+  confirm) → silent success (safe abandonment); next sync re-presents
+  all 5 items from scratch, including the 2 already decided.
+- **TC-5.16** `Cancel review` → confirm exactly *"Stop reviewing? None
+  of your choices in this session will be saved. You can sync again
+  anytime."*; "Keep reviewing" leaves wizard state intact; "Stop
+  reviewing" returns to `/data-management`, no message.
+- **TC-5.17** Same as TC-5.15 via the header account icon instead of the
+  tab bar → same silent-abandonment behavior.
+- **TC-5.18** Accept/reject through several items → visible "Item N of
+  M" updates; `aria-live` node's text equals only the progress string,
+  not the full card.
+- **TC-5.19** Mount `/sync-review` → focus on `h1`; accept one item →
+  focus moves to the new card's container (`tabIndex={-1}`).
+- **TC-5.20** Inspect action buttons on a $42.10-expense-by-Tom card →
+  `aria-label`s like `"Accept $42.10 expense added by Tom"`, distinct
+  per action; visible labels stay short.
+- **TC-5.21** One card per kind → badge color/label: Income/`$income`,
+  Expense/`$expense`, Fixed Income/`$income`, Fixed Expense/`$expense`,
+  Bucket/`$accent`.
+- **TC-5.22** Bucket-kind card → shows name + monthly allowance; no
+  amount/description/category/date fields.
+
+### PR 6 — Docs + DoD hardening
+
+No new user-facing behavior; obligation is closing gaps this plan and
+`TASKS.md`'s own DoD audit surface:
+- **TC-6.1 [QA]** Every **[QA]** test above (SC-1.8, TC-1.7, TC-1.11,
+  TC-2.2, TC-2.8, TC-2.9, TC-3.6, TC-4.10) exists and passes — if
+  deferred instead of added to its originating PR, PR6 must add it.
+- **TC-6.2 [QA]** Every PRD §7 DoD checkbox has ≥1 test ID against it
+  (cross-check §2); any checkbox with none blocks PR6 sign-off.
+- §6 covers the accompanying manual/code checklist, including confirming
+  `server/lambda.js`/`storage-s3.js` exist and are documented as not
+  CI-exercised (per `TASKS.md`), not silently dropped.
+
+---
+
+## 4. Regression suite
+
+Must stay green **and unmodified** (NFR-3) on every PR:
+
+- `bucketLimitEdits`, `bucketSpentAndRemaining`, `bucketsCarryOn`,
+  `bucketsEmptyState`, `categoryBucketCreation`, `dataReading`,
+  `entryCreation`, `fixedEntries`, `navigation`, `singleFileBackup`
+  (all `.test.tsx`) — zero diffs to these files across all 6 PRs unless
+  explicitly justified per NFR-3 ("strictly necessary and directly
+  caused by this feature") — treat any such diff as a flagged review
+  item, not routine.
+- Download Backup / Restore Backup / Clear All Data: identical copy,
+  confirms, and replace (not merge) semantics before/after PR4 (TC-4.11).
+- A user who never signs up: every route renders, every action works,
+  zero sync DOM present (TC-1.6).
+- Existing routes unchanged in path/behavior; new routes (`/account`,
+  `/sign-up`, `/sign-in`, `/party`, `/party/invite`, `/party/join`,
+  `/sync-review`) are additive only.
+- `npm run typecheck` and `npm run lint` pass on every PR, not just the
+  last one.
+
+---
+
+## 5. Accessibility checks
+
+| # | Check | Pass condition |
+|---|---|---|
+| A1 | Wizard mount focus | `/sync-review` mount moves focus to `h1` (TC-5.19). |
+| A2 | Wizard advance focus | Accept/Reject/Save&accept moves focus to next card container, not page top (TC-5.19). |
+| A3 | `role="alert"` on errors | Auth (TC-1.2/1.3), invitation (TC-2.6/2.7/2.8), download/upload failure (TC-4.6/5.10), blocked/canceled (TC-4.7/4.8/5.12), version conflict (TC-5.11). |
+| A4 | `role="status"` on confirmations | "You're up to date.", "Signed out…", EC-1 confirmation, wizard success — never `role="alert"`. |
+| A5 | `aria-live="polite"` regions | Progress count (TC-5.18), syncing text (TC-4.9), uploading text (TC-5.9), "Copied" (TC-2.3) — the live node itself contains only the short text, not the whole card. |
+| A6 | Button accessible names | Header icon `aria-label="Account"`/`"Account: {name}"` (TC-1.10); wizard actions item-specific (TC-5.20). |
+| A7 | Disabled-state explanation always rendered | The 5 gating captions (TC-4.1) are in the DOM unconditionally — not a tooltip, not hover/focus-only. |
+| A8 | Touch targets | Header icon ≥44×44px; `.btn` height stays ~50px — spot-check computed style in one wizard test, one account test. |
+| A9 | Focus rings | Every new interactive element (header icon, Block button, invite Copy buttons, wizard actions, Accept/Reject all, InputDate) has `:focus-visible` styling — verify by selector presence in compiled SCSS during PR6 (jsdom won't render it). |
+
+---
+
+## 6. Post-merge QA execution plan
+
+Run after PR5 (feature-complete) and again after PR6:
+
+1. `npm run typecheck` — zero errors.
+2. `npm run lint` — zero errors.
+3. `npm run test:server` (`node --test server/`) — all SC-x pass.
+4. `npm test -- --testPathPattern="integrationTests" --watchAll=false` —
+   all TC-x/UT-4.x pass; all §4 files pass unmodified.
+5. **Manual exploratory:**
+   - MX-1: `npm run sync-server` — listens on `:4000`, no crash;
+     `server/.data/` created and git-ignored (`git status` clean).
+   - MX-2: sign up as Jane (profile A), fully close/reopen the browser —
+     still logged in (real restart, vs. TC-1.4's re-mount analogue).
+   - MX-3: Jane creates a party, invites Tom (profile B), who redeems it;
+     Jane blocks Tom; Tom's next sync is rejected live (not stubbed).
+   - MX-4: real two-tab CAS race for EC-2 — two tabs download the same
+     backup, one uploads first, the other's upload gets a live `409`
+     with the conflict copy.
+   - MX-5: kill `sync-server` mid-sync (real offline) — "Couldn't reach
+     your party" path fires against the real process, not the stub.
+6. **Code-level inspection:**
+   - `grep -RIn` for the literal invite password and a test user's
+     password across `server/.data/` and sync-server stdout from MX-3 —
+     zero plaintext hits (AC-1.2, AC-2.4, NFR-2).
+   - Open `server/.data/parties/<id>.json` after MX-3, confirm
+     `invitations` values are AES-GCM ciphertext, not readable fields.
+   - Confirm `server/lambda.js`/`server/storage-s3.js` exist, mirror
+     `server/core`'s interface, and are documented as not CI-exercised.
+   - Diff `package.json`/`package-lock.json`/`CHANGELOG.md` across all 6
+     PRs — version bump + changelog entry present each time, matching
+     `TASKS.md` (1.2.0 → 1.6.1).
+   - Re-check §2's matrix against the final PRD §7 DoD list — every
+     checkbox has a passing test ID; any without one blocks sign-off.

--- a/docs/multi-user-sync/feature-brief.md
+++ b/docs/multi-user-sync/feature-brief.md
@@ -1,0 +1,73 @@
+# Feature Brief: Multi-User Sync for the Family Expenses Tracker
+
+This is the source-of-truth brief for the multi-user sync feature. All roles
+(PM, Designer, Tech Lead, Contributor, QA) work from this document.
+
+## Objective
+
+Let multiple users collaborate on the expenses tracker without data loss or
+collisions, making the app the single source of truth for family finances
+(replacing Google Drive spreadsheets). Add cross-device sync.
+
+## Scope
+
+### Accounts
+
+Implement the simplest possible auth (signup/login): lowest cost, secure,
+minimal. Accounts identify who added each entry.
+
+### Sync
+
+- `localStorage` is the runtime source of truth.
+- Reuse the existing backup system: sync = download the latest backup and
+  **merge** it. The existing download/restore keeps its **replace** strategy —
+  do not change it.
+- Sync is **manual**, triggered by a button, and only allowed if the user
+  belongs to a party.
+- After downloading the latest backup, show a **wizard** to review each
+  incoming entry: accept / reject / modify. Allow skipping review (accept-all
+  or reject-all).
+- Show who added the entry under review.
+- After review, treat the local file as latest and upload it as the new backup.
+- Sync entries, fixed entries, **and** buckets.
+- Idempotent: already-applied updates are never duplicated.
+- When local data is already up to date, notify the user; no further action
+  needed.
+
+### Parties (households/families)
+
+- A user belongs to exactly one party.
+- Invitations = an encrypted **token + password** (inviter sets the password;
+  invitee enters it). Tokens and passwords MUST be encrypted.
+- An invitation can be accepted only once.
+- The inviter can manage the party: cancel it, add users, block users.
+
+## Suggested Setup
+
+Change this freely if a cheaper, simpler, cleaner, or more cost-effective
+approach still meets the requirements.
+
+- **AWS Lambda:** download backups, upload backups, send invitations,
+  (optionally) login.
+- **AWS S3:** store backups.
+- **Database** (MongoDB or similar): store invitation tokens.
+
+Provide a **local implementation** of every third-party dependency so the
+whole feature can be spun up and fully tested locally without live AWS.
+Clearly document the steps needed to configure the real third-party services.
+
+## Constraints
+
+- Cost-effective.
+- No regressions; do not break existing functionality.
+- Do not modify existing integration tests unless strictly necessary and
+  directly related to this change.
+- Add integration tests for the new functionality that do **not** require
+  third-party connections. Verify through user-facing interactions, not by
+  inspecting `localStorage` or React state (unless strictly necessary).
+
+## Git
+
+- `sync` is the feature branch and the base for **all** PRs. Merge everything
+  into `sync`, never `master`.
+- PRs may be stacked.


### PR DESCRIPTION
**Stacked PR 1 of 9** — re-breaking the large `sync` → `master` PR (#128) into small, coherent, individually-green pieces for review. Together the 9 PRs equal `sync`; each stacks on the previous one.

> **Note on the base:** this stack is based on the same commit `sync` forked from (`45f811c`), so PRs read as clean incremental diffs. Because `master` has since merged parallel UX work (searchable categories, filter/sort, visual refresh), **this first PR into `master` will show merge conflicts** — that's expected and acceptable per the review plan; integration with `master` is a deliberate later step, not part of this review pass. `sync` itself is untouched.

## This PR
Documentation only — the planning artifacts the feature was built from, with no code changes:
- `docs/multi-user-sync/feature-brief.md`, `PRD.md`, `DESIGN.md`, `RFC.md`, `TASKS.md`, `TEST-PLAN.md`

Reviewing these first gives the context for the code PRs that follow (each maps to a section of `TASKS.md`).

Diff: 6 files, docs only. No app code, so nothing to break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XK2sxKjRfUxBMqyQHypqLB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XK2sxKjRfUxBMqyQHypqLB)_