### PR TITLE
Fix bucket usage percentage for carried debt exceeding the allowance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.1] - 2026-08-02
+
+### Fixed
+- Buckets: adding or editing a bucket now rejects a negative monthly
+  allowance, both in the form (clear inline error, "Allowance cannot be
+  negative") and at the storage layer as a safety net. Previously a negative
+  value could only be blocked by the input's regex silently swallowing the
+  keystroke, with no explicit validation or error message
+
 ## [1.6.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.1] - 2026-08-01
+
+### Fixed
+- Buckets: a bucket whose carried-over debt already exceeds its allowance
+  (zero or negative availability) now shows 100% usage with the red/danger
+  indicator, even if nothing has been spent yet this month. Previously it
+  fell back to 0% whenever this month's spending was $0, hiding the overspend
+  carried in from prior months
+
 ## [1.6.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,6 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.6.1] - 2026-08-01
-
-### Fixed
-- Buckets: a bucket whose carried-over debt already exceeds its allowance
-  (zero or negative availability) now shows 100% usage with the red/danger
-  indicator, even if nothing has been spent yet this month. Previously it
-  fell back to 0% whenever this month's spending was $0, hiding the overspend
-  carried in from prior months
-
 ## [1.6.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.2] - 2026-08-02
+
+### Fixed
+- Buckets: a bucket whose carried-over debt already exceeds its allowance
+  (zero or negative availability) now shows a magnitude-aware usage
+  percentage with the danger/red indicator, instead of falling back to 0%
+  whenever nothing had been spent yet this month. The percentage now reads
+  as "100% + how far past the allowance the carried debt goes" (e.g. a $300
+  debt against a $200 allowance reads 150%, not a flat, uninformative 100%)
+  (issue #155)
+
 ## [1.6.1] - 2026-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.3] - 2026-08-02
+
+### Changed
+- Buckets: a monthly allowance of exactly 0 is now rejected, not just
+  negative values — the allowance validation (form + storage layer) now
+  requires a value strictly greater than zero. This also closes the open
+  "what if allowance is 0" gap flagged in issue #155, since a zero allowance
+  would have made the carry-on percentage calculation divide by zero
+
 ## [1.6.2] - 2026-08-02
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.1",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.6.1",
+      "version": "1.6.0",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.1",
+  "version": "1.6.0",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/src/components/common/ExpensesManager/AddBucket/index.js
+++ b/src/components/common/ExpensesManager/AddBucket/index.js
@@ -9,10 +9,10 @@ import ContentTileSection from "../../ContentTitleSection";
 import { addBucket } from "../../../../redux/expensesManager/actionCreators";
 import {
   getBucketValidationError,
+  getBucketAllowanceValidationError,
   getUnbudgetedCategories,
 } from "../../../../helpers/entriesHelper/entriesHelper";
 
-const DIGIT_MATCHER = /^\d*(\.)*\d+$/;
 const BUCKETS_ROUTE = "/buckets";
 
 /**
@@ -41,8 +41,9 @@ const AddBucket = ({ buckets, unbudgetedCategories, onAddBucket, history }) => {
       return;
     }
 
-    if (!DIGIT_MATCHER.test(allowance)) {
-      setError("Allowance must be a valid number");
+    const allowanceError = getBucketAllowanceValidationError(allowance);
+    if (allowanceError) {
+      setError(allowanceError);
       return;
     }
 

--- a/src/components/common/ExpensesManager/Buckets/index.tsx
+++ b/src/components/common/ExpensesManager/Buckets/index.tsx
@@ -34,14 +34,15 @@ const Buckets = ({ selectedDate, entries, history, buckets }) => {
     .map((bucketName) => {
       const { allowance, carryOver, availability, spending, remainder } =
         carriedBuckets[bucketName];
-      // Availability can be zero or negative once debt is carried over, so we
-      // guard the percentage calculation (it rejects a zero/undefined whole).
+      // Availability can be zero or negative once debt is carried over. In
+      // that case the debt itself (allowance - availability) already counts
+      // as consumption against the allowance, on top of any new spending, so
+      // the percentage is read as "how far past the 100% line" rather than
+      // clamped to a fixed number (issue #155).
       const consuptionPercentage =
         availability > 0
           ? calculatePercentage(spending, availability)
-          : spending > 0
-            ? 100
-            : 0;
+          : 100 + calculatePercentage(spending - availability, allowance);
       return {
         name: bucketName.toLowerCase(),
         label: bucketName,

--- a/src/components/common/ExpensesManager/Buckets/index.tsx
+++ b/src/components/common/ExpensesManager/Buckets/index.tsx
@@ -36,11 +36,12 @@ const Buckets = ({ selectedDate, entries, history, buckets }) => {
         carriedBuckets[bucketName];
       // Availability can be zero or negative once debt is carried over, so we
       // guard the percentage calculation (it rejects a zero/undefined whole).
-      // A zero/negative availability means the bucket is already fully
-      // consumed (or over) regardless of this month's spending, so it must
-      // read as 100% rather than falling back to 0%.
       const consuptionPercentage =
-        availability > 0 ? calculatePercentage(spending, availability) : 100;
+        availability > 0
+          ? calculatePercentage(spending, availability)
+          : spending > 0
+            ? 100
+            : 0;
       return {
         name: bucketName.toLowerCase(),
         label: bucketName,

--- a/src/components/common/ExpensesManager/Buckets/index.tsx
+++ b/src/components/common/ExpensesManager/Buckets/index.tsx
@@ -36,12 +36,11 @@ const Buckets = ({ selectedDate, entries, history, buckets }) => {
         carriedBuckets[bucketName];
       // Availability can be zero or negative once debt is carried over, so we
       // guard the percentage calculation (it rejects a zero/undefined whole).
+      // A zero/negative availability means the bucket is already fully
+      // consumed (or over) regardless of this month's spending, so it must
+      // read as 100% rather than falling back to 0%.
       const consuptionPercentage =
-        availability > 0
-          ? calculatePercentage(spending, availability)
-          : spending > 0
-            ? 100
-            : 0;
+        availability > 0 ? calculatePercentage(spending, availability) : 100;
       return {
         name: bucketName.toLowerCase(),
         label: bucketName,

--- a/src/components/common/ExpensesManager/EditBucket/EditBucket.tsx
+++ b/src/components/common/ExpensesManager/EditBucket/EditBucket.tsx
@@ -9,12 +9,19 @@ import {
 } from "../../../../redux/expensesManager/actionCreators";
 import { FormButton, FormContent, InputNumber } from "../../Forms";
 import { Col, Form, Row, Button } from "react-bootstrap";
-import { getActiveLimitForMonth, toYearMonth } from "../../../../helpers/entriesHelper/entriesHelper";
+import {
+  getActiveLimitForMonth,
+  getBucketAllowanceValidationError,
+  toYearMonth,
+} from "../../../../helpers/entriesHelper/entriesHelper";
+
+const ALLOWANCE_MATCHER = /^-?\d*(\.)*\d+$/;
 
 const EditBucket = ({ onGetBucket, onEditBucket, history, selectedDate }) => {
   const params = useParams();
   const { bucketName } = params;
   const [bucket, setBucket] = useState<{ name: string; value: number | "" }>({ name: "", value: 0 });
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -48,6 +55,13 @@ const EditBucket = ({ onGetBucket, onEditBucket, history, selectedDate }) => {
         formProps={{
           onSubmit: (event) => {
             event.preventDefault();
+
+            const allowanceError = getBucketAllowanceValidationError(bucket.value);
+            if (allowanceError) {
+              setError(allowanceError);
+              return;
+            }
+
             const editedBucket = { [bucket.name]: Number(bucket.value) };
             saveBucket(editedBucket);
             history.goBack();
@@ -75,12 +89,12 @@ const EditBucket = ({ onGetBucket, onEditBucket, history, selectedDate }) => {
                       value={bucket?.value}
                       onChange={(event) => {
                         const value = event?.currentTarget?.value;
+                        setError(null);
                         if (!value) {
                           setBucket({ name: bucket?.name, value: "" });
                           return;
                         }
-                        const digitMatcher = /^\d*(\.)*\d+$/;
-                        if (digitMatcher.test(value)) {
+                        if (ALLOWANCE_MATCHER.test(value)) {
                           setBucket({
                             name: bucket?.name,
                             value: parseFloat(value),
@@ -89,6 +103,11 @@ const EditBucket = ({ onGetBucket, onEditBucket, history, selectedDate }) => {
                       }}
                     ></InputNumber>
                   </Form.Group>
+                  {error && (
+                    <p className="edit-bucket-error text-danger" role="alert">
+                      {error}
+                    </p>
+                  )}
                 </Col>
               </Row>
               <Row className="bottom-container container-fluid vertical-standard-space">

--- a/src/helpers/entriesHelper/categoryBuckets.test.js
+++ b/src/helpers/entriesHelper/categoryBuckets.test.js
@@ -142,9 +142,14 @@ describe("category/bucket helpers (issue #100)", () => {
 
   describe("getBucketAllowanceValidationError", () => {
     it("rejects a negative allowance", () => {
-      expect(getBucketAllowanceValidationError("-100")).toMatch(/cannot be negative/i);
-      expect(getBucketAllowanceValidationError(-50)).toMatch(/cannot be negative/i);
-      expect(getBucketAllowanceValidationError("-0.01")).toMatch(/cannot be negative/i);
+      expect(getBucketAllowanceValidationError("-100")).toMatch(/greater than zero/i);
+      expect(getBucketAllowanceValidationError(-50)).toMatch(/greater than zero/i);
+      expect(getBucketAllowanceValidationError("-0.01")).toMatch(/greater than zero/i);
+    });
+
+    it("rejects a zero allowance", () => {
+      expect(getBucketAllowanceValidationError("0")).toMatch(/greater than zero/i);
+      expect(getBucketAllowanceValidationError(0)).toMatch(/greater than zero/i);
     });
 
     it("rejects a non-numeric allowance", () => {
@@ -152,8 +157,7 @@ describe("category/bucket helpers (issue #100)", () => {
       expect(getBucketAllowanceValidationError("")).toMatch(/valid number/i);
     });
 
-    it("accepts zero and positive allowances", () => {
-      expect(getBucketAllowanceValidationError("0")).toBeNull();
+    it("accepts positive allowances", () => {
       expect(getBucketAllowanceValidationError(200)).toBeNull();
       expect(getBucketAllowanceValidationError("199.99")).toBeNull();
     });

--- a/src/helpers/entriesHelper/categoryBuckets.test.js
+++ b/src/helpers/entriesHelper/categoryBuckets.test.js
@@ -5,6 +5,7 @@ const {
   getCategoryValidationError,
   getUnbudgetedCategories,
   getBucketValidationError,
+  getBucketAllowanceValidationError,
 } = require("./entriesHelper");
 
 describe("category/bucket helpers (issue #100)", () => {
@@ -136,6 +137,25 @@ describe("category/bucket helpers (issue #100)", () => {
       expect(
         getBucketValidationError({ categoryName: "Gym", buckets: { Food: 200 } })
       ).toBeNull();
+    });
+  });
+
+  describe("getBucketAllowanceValidationError", () => {
+    it("rejects a negative allowance", () => {
+      expect(getBucketAllowanceValidationError("-100")).toMatch(/cannot be negative/i);
+      expect(getBucketAllowanceValidationError(-50)).toMatch(/cannot be negative/i);
+      expect(getBucketAllowanceValidationError("-0.01")).toMatch(/cannot be negative/i);
+    });
+
+    it("rejects a non-numeric allowance", () => {
+      expect(getBucketAllowanceValidationError("abc")).toMatch(/valid number/i);
+      expect(getBucketAllowanceValidationError("")).toMatch(/valid number/i);
+    });
+
+    it("accepts zero and positive allowances", () => {
+      expect(getBucketAllowanceValidationError("0")).toBeNull();
+      expect(getBucketAllowanceValidationError(200)).toBeNull();
+      expect(getBucketAllowanceValidationError("199.99")).toBeNull();
     });
   });
 });

--- a/src/helpers/entriesHelper/entriesHelper.js
+++ b/src/helpers/entriesHelper/entriesHelper.js
@@ -279,6 +279,30 @@ function getBucketValidationError({ categoryName, buckets = {} }) {
   return null;
 }
 
+const BUCKET_ALLOWANCE_MATCHER = /^-?\d*(\.)*\d+$/;
+
+/**
+ * Validates a bucket's monthly allowance (used by both AddBucket and
+ * EditBucket): it must be a well-formed number and cannot be negative, since
+ * a negative spending limit has no meaning.
+ *
+ * @param {string|number} allowance - The raw allowance value from the form.
+ * @returns {string|null} An error message, or null when the allowance is valid.
+ */
+function getBucketAllowanceValidationError(allowance) {
+  const trimmedAllowance = String(allowance ?? "").trim();
+
+  if (!BUCKET_ALLOWANCE_MATCHER.test(trimmedAllowance)) {
+    return "Allowance must be a valid number";
+  }
+
+  if (parseFloat(trimmedAllowance) < 0) {
+    return "Allowance cannot be negative";
+  }
+
+  return null;
+}
+
 const getEmtpyMonthModel = () => ({
   incomes: [],
   expenses: [],
@@ -642,6 +666,7 @@ export {
   getCategoryValidationError,
   getUnbudgetedCategories,
   getBucketValidationError,
+  getBucketAllowanceValidationError,
   getGroupedFilledEntriesByDate,
   quantitiesToPercentages,
   getFilteredEntriesByCategory,

--- a/src/helpers/entriesHelper/entriesHelper.js
+++ b/src/helpers/entriesHelper/entriesHelper.js
@@ -283,8 +283,9 @@ const BUCKET_ALLOWANCE_MATCHER = /^-?\d*(\.)*\d+$/;
 
 /**
  * Validates a bucket's monthly allowance (used by both AddBucket and
- * EditBucket): it must be a well-formed number and cannot be negative, since
- * a negative spending limit has no meaning.
+ * EditBucket): it must be a well-formed number greater than zero, since a
+ * zero or negative spending limit has no meaning (a zero allowance also
+ * breaks the carry-on percentage calculation, which divides by it).
  *
  * @param {string|number} allowance - The raw allowance value from the form.
  * @returns {string|null} An error message, or null when the allowance is valid.
@@ -296,8 +297,8 @@ function getBucketAllowanceValidationError(allowance) {
     return "Allowance must be a valid number";
   }
 
-  if (parseFloat(trimmedAllowance) < 0) {
-    return "Allowance cannot be negative";
+  if (parseFloat(trimmedAllowance) <= 0) {
+    return "Allowance must be greater than zero";
   }
 
   return null;

--- a/src/integrationTests/bucketLimitEdits.test.tsx
+++ b/src/integrationTests/bucketLimitEdits.test.tsx
@@ -233,7 +233,36 @@ describe("per-month bucket limit edits (issue #102)", () => {
     await user.type(input, "-50");
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(/cannot be negative/i);
+    expect(await screen.findByRole("alert")).toHaveTextContent(/greater than zero/i);
+
+    // Still on the edit form, and the stored limit is untouched.
+    expect(screen.getByPlaceholderText(/insert bucket amount/i)).toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem("buckets") || "{}")).toEqual({
+      Food: [{ from: "0000-00", limit: 200 }],
+    });
+  });
+
+  it("rejects a zero allowance and leaves the existing limit untouched", async () => {
+    localStorage.setItem(
+      "buckets",
+      JSON.stringify({ Food: [{ from: "0000-00", limit: 200 }] })
+    );
+    seedEntries([
+      { date: ts(2026, JANUARY), amount: "100", type: "income", categories_path: ",salary," },
+    ]);
+
+    const { user } = await renderApp("/buckets");
+    await screen.findByText("May 2026");
+
+    await user.click(await screen.findByRole("link", { name: /edit food/i }));
+    await screen.findByText(/edit bucket: food/i);
+
+    const input = screen.getByPlaceholderText(/insert bucket amount/i);
+    await user.clear(input);
+    await user.type(input, "0");
+    await user.click(screen.getByRole("button", { name: /submit/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/greater than zero/i);
 
     // Still on the edit form, and the stored limit is untouched.
     expect(screen.getByPlaceholderText(/insert bucket amount/i)).toBeInTheDocument();

--- a/src/integrationTests/bucketLimitEdits.test.tsx
+++ b/src/integrationTests/bucketLimitEdits.test.tsx
@@ -212,4 +212,33 @@ describe("per-month bucket limit edits (issue #102)", () => {
     );
     expect(bucketRemaining("bucket-food")).toBe("Remaining: $250.00");
   });
+
+  it("rejects a negative allowance and leaves the existing limit untouched", async () => {
+    localStorage.setItem(
+      "buckets",
+      JSON.stringify({ Food: [{ from: "0000-00", limit: 200 }] })
+    );
+    seedEntries([
+      { date: ts(2026, JANUARY), amount: "100", type: "income", categories_path: ",salary," },
+    ]);
+
+    const { user } = await renderApp("/buckets");
+    await screen.findByText("May 2026");
+
+    await user.click(await screen.findByRole("link", { name: /edit food/i }));
+    await screen.findByText(/edit bucket: food/i);
+
+    const input = screen.getByPlaceholderText(/insert bucket amount/i);
+    await user.clear(input);
+    await user.type(input, "-50");
+    await user.click(screen.getByRole("button", { name: /submit/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/cannot be negative/i);
+
+    // Still on the edit form, and the stored limit is untouched.
+    expect(screen.getByPlaceholderText(/insert bucket amount/i)).toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem("buckets") || "{}")).toEqual({
+      Food: [{ from: "0000-00", limit: 200 }],
+    });
+  });
 });

--- a/src/integrationTests/bucketsCarryOn.test.tsx
+++ b/src/integrationTests/bucketsCarryOn.test.tsx
@@ -186,5 +186,15 @@ describe("buckets carry-on (issue #97)", () => {
     // negative amount.
     expect(bucketSpending("bucket-food")).toBe("Spent: $0.00");
     expect(bucketRemaining("bucket-food")).toBe("Remaining: -$100.00");
+
+    // Even with no spending this month, the $300 carried debt against a $200
+    // allowance already amounts to 150% consumption (100% + 50% of the
+    // allowance over the line), shown with the danger/red indicator (issue #155).
+    expect(screen.getByTestId("bucket-food-percentage").textContent).toBe(
+      "150%"
+    );
+    expect(screen.getByTestId("bucket-food-percentage").className).toContain(
+      "danger"
+    );
   });
 });

--- a/src/integrationTests/bucketsCarryOn.test.tsx
+++ b/src/integrationTests/bucketsCarryOn.test.tsx
@@ -186,5 +186,15 @@ describe("buckets carry-on (issue #97)", () => {
     // negative amount.
     expect(bucketSpending("bucket-food")).toBe("Spent: $0.00");
     expect(bucketRemaining("bucket-food")).toBe("Remaining: -$100.00");
+
+    // Even with no spending this month, the carried debt already exceeds the
+    // allowance, so the bucket reads as fully consumed (100%, danger/red)
+    // rather than 0%.
+    expect(screen.getByTestId("bucket-food-percentage").textContent).toBe(
+      "100%"
+    );
+    expect(screen.getByTestId("bucket-food-percentage").className).toContain(
+      "danger"
+    );
   });
 });

--- a/src/integrationTests/bucketsCarryOn.test.tsx
+++ b/src/integrationTests/bucketsCarryOn.test.tsx
@@ -186,6 +186,16 @@ describe("buckets carry-on (issue #97)", () => {
     // negative amount.
     expect(bucketSpending("bucket-food")).toBe("Spent: $0.00");
     expect(bucketRemaining("bucket-food")).toBe("Remaining: -$100.00");
+  });
+
+  it("shows a magnitude-aware percentage with the danger indicator when carried debt exceeds the allowance", async () => {
+    // Same setup as above: allowance 200, carried debt -300 -> availability -100.
+    seedEntries([
+      { date: ts(2026, APRIL), amount: "500", type: "expense", categories_path: ",food," },
+    ]);
+
+    await renderApp("/buckets");
+    await screen.findByText("May 2026");
 
     // Even with no spending this month, the $300 carried debt against a $200
     // allowance already amounts to 150% consumption (100% + 50% of the

--- a/src/integrationTests/bucketsCarryOn.test.tsx
+++ b/src/integrationTests/bucketsCarryOn.test.tsx
@@ -186,15 +186,5 @@ describe("buckets carry-on (issue #97)", () => {
     // negative amount.
     expect(bucketSpending("bucket-food")).toBe("Spent: $0.00");
     expect(bucketRemaining("bucket-food")).toBe("Remaining: -$100.00");
-
-    // Even with no spending this month, the carried debt already exceeds the
-    // allowance, so the bucket reads as fully consumed (100%, danger/red)
-    // rather than 0%.
-    expect(screen.getByTestId("bucket-food-percentage").textContent).toBe(
-      "100%"
-    );
-    expect(screen.getByTestId("bucket-food-percentage").className).toContain(
-      "danger"
-    );
   });
 });

--- a/src/integrationTests/categoryBucketCreation.test.tsx
+++ b/src/integrationTests/categoryBucketCreation.test.tsx
@@ -105,4 +105,24 @@ describe("category + bucket creation (issue #100)", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent(/cannot be empty/i);
   });
+
+  it("rejects a negative allowance and creates nothing", async () => {
+    localStorage.setItem("categories", JSON.stringify(["Gym"]));
+    const { user } = await renderApp("/add-bucket");
+
+    await selectCategory(user, "Gym");
+    await user.type(
+      screen.getByPlaceholderText(/insert bucket allowance/i),
+      "-50"
+    );
+    await user.click(screen.getByRole("button", { name: /submit/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/cannot be negative/i);
+
+    // We must still be on the add-bucket form, and storage must be untouched.
+    expect(screen.getByPlaceholderText(/insert bucket allowance/i)).toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem("buckets") || "{}")).toEqual({
+      Food: 200,
+    });
+  });
 });

--- a/src/integrationTests/categoryBucketCreation.test.tsx
+++ b/src/integrationTests/categoryBucketCreation.test.tsx
@@ -117,7 +117,27 @@ describe("category + bucket creation (issue #100)", () => {
     );
     await user.click(screen.getByRole("button", { name: /submit/i }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(/cannot be negative/i);
+    expect(await screen.findByRole("alert")).toHaveTextContent(/greater than zero/i);
+
+    // We must still be on the add-bucket form, and storage must be untouched.
+    expect(screen.getByPlaceholderText(/insert bucket allowance/i)).toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem("buckets") || "{}")).toEqual({
+      Food: 200,
+    });
+  });
+
+  it("rejects a zero allowance and creates nothing", async () => {
+    localStorage.setItem("categories", JSON.stringify(["Gym"]));
+    const { user } = await renderApp("/add-bucket");
+
+    await selectCategory(user, "Gym");
+    await user.type(
+      screen.getByPlaceholderText(/insert bucket allowance/i),
+      "0"
+    );
+    await user.click(screen.getByRole("button", { name: /submit/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/greater than zero/i);
 
     // We must still be on the add-bucket form, and storage must be untouched.
     expect(screen.getByPlaceholderText(/insert bucket allowance/i)).toBeInTheDocument();

--- a/src/services/storageSelector/LocalStorage/addBucket.test.js
+++ b/src/services/storageSelector/LocalStorage/addBucket.test.js
@@ -47,7 +47,14 @@ describe("LocalStorage.addBucket (issue #100)", () => {
   it("rejects a negative allowance without persisting", async () => {
     await expect(
       storage.addBucket({ bucket: { Gym: -50 } })
-    ).rejects.toThrow(/cannot be negative/i);
+    ).rejects.toThrow(/greater than zero/i);
+    expect(JSON.parse(localStorage.getItem("buckets") || "{}")).toEqual({});
+  });
+
+  it("rejects a zero allowance without persisting", async () => {
+    await expect(
+      storage.addBucket({ bucket: { Gym: 0 } })
+    ).rejects.toThrow(/greater than zero/i);
     expect(JSON.parse(localStorage.getItem("buckets") || "{}")).toEqual({});
   });
 

--- a/src/services/storageSelector/LocalStorage/addBucket.test.js
+++ b/src/services/storageSelector/LocalStorage/addBucket.test.js
@@ -44,6 +44,13 @@ describe("LocalStorage.addBucket (issue #100)", () => {
     ).rejects.toThrow(/cannot be empty/i);
   });
 
+  it("rejects a negative allowance without persisting", async () => {
+    await expect(
+      storage.addBucket({ bucket: { Gym: -50 } })
+    ).rejects.toThrow(/cannot be negative/i);
+    expect(JSON.parse(localStorage.getItem("buckets") || "{}")).toEqual({});
+  });
+
   it("removes the category from the standalone categories list once it gets a bucket", async () => {
     localStorage.setItem("categories", JSON.stringify(["Gym", "Yoga"]));
 

--- a/src/services/storageSelector/LocalStorage/editBucket.test.js
+++ b/src/services/storageSelector/LocalStorage/editBucket.test.js
@@ -16,25 +16,25 @@ describe("LocalStorage.editBucket (issue #102)", () => {
 
     await expect(
       storage.editBucket({ bucketName: "Food", limit: -50, fromYearMonth: "2026-03" })
-    ).rejects.toThrow(/cannot be negative/i);
+    ).rejects.toThrow(/greater than zero/i);
 
     expect(JSON.parse(localStorage.getItem("buckets"))).toEqual({
       Food: [{ from: "0000-00", limit: 200 }],
     });
   });
 
-  it("accepts a zero limit", async () => {
+  it("rejects a zero limit without persisting", async () => {
     localStorage.setItem(
       "buckets",
       JSON.stringify({ Food: [{ from: "0000-00", limit: 200 }] })
     );
 
-    const result = await storage.editBucket({
-      bucketName: "Food",
-      limit: 0,
-      fromYearMonth: "2026-03",
-    });
+    await expect(
+      storage.editBucket({ bucketName: "Food", limit: 0, fromYearMonth: "2026-03" })
+    ).rejects.toThrow(/greater than zero/i);
 
-    expect(result.Food).toContainEqual({ from: "2026-03", limit: 0 });
+    expect(JSON.parse(localStorage.getItem("buckets"))).toEqual({
+      Food: [{ from: "0000-00", limit: 200 }],
+    });
   });
 });

--- a/src/services/storageSelector/LocalStorage/editBucket.test.js
+++ b/src/services/storageSelector/LocalStorage/editBucket.test.js
@@ -1,0 +1,40 @@
+import LocalStorage from "./index";
+
+describe("LocalStorage.editBucket (issue #102)", () => {
+  let storage;
+
+  beforeEach(() => {
+    localStorage.clear();
+    storage = LocalStorage();
+  });
+
+  it("rejects a negative limit without persisting", async () => {
+    localStorage.setItem(
+      "buckets",
+      JSON.stringify({ Food: [{ from: "0000-00", limit: 200 }] })
+    );
+
+    await expect(
+      storage.editBucket({ bucketName: "Food", limit: -50, fromYearMonth: "2026-03" })
+    ).rejects.toThrow(/cannot be negative/i);
+
+    expect(JSON.parse(localStorage.getItem("buckets"))).toEqual({
+      Food: [{ from: "0000-00", limit: 200 }],
+    });
+  });
+
+  it("accepts a zero limit", async () => {
+    localStorage.setItem(
+      "buckets",
+      JSON.stringify({ Food: [{ from: "0000-00", limit: 200 }] })
+    );
+
+    const result = await storage.editBucket({
+      bucketName: "Food",
+      limit: 0,
+      fromYearMonth: "2026-03",
+    });
+
+    expect(result.Food).toContainEqual({ from: "2026-03", limit: 0 });
+  });
+});

--- a/src/services/storageSelector/LocalStorage/index.js
+++ b/src/services/storageSelector/LocalStorage/index.js
@@ -132,6 +132,7 @@ const normalizeBucketValue = (value) => {
 // to the array form on the first edit.
 const editBucketForMonth = async ({ bucketName, limit, fromYearMonth }) => {
   if (!bucketName) throw new Error("No bucket name was set");
+  if (Number(limit) < 0) throw new Error("Allowance cannot be negative");
   const storedBuckets = (await getBucketsFromLocalStorage()) || {};
   const historyBuckets = normalizeBucketValue(storedBuckets[bucketName] ?? 0);
 
@@ -183,6 +184,7 @@ const addBucketData = async ({ bucket }) => {
   const [name, value] = Object.entries(bucket)[0] || [];
   const trimmedName = (name || "").trim();
   if (!trimmedName) throw new Error("Category name cannot be empty");
+  if (Number(value) < 0) throw new Error("Allowance cannot be negative");
 
   const storedBuckets = (await getBucketsFromLocalStorage()) || {};
   const alreadyExists = Object.keys(storedBuckets).some(

--- a/src/services/storageSelector/LocalStorage/index.js
+++ b/src/services/storageSelector/LocalStorage/index.js
@@ -132,7 +132,7 @@ const normalizeBucketValue = (value) => {
 // to the array form on the first edit.
 const editBucketForMonth = async ({ bucketName, limit, fromYearMonth }) => {
   if (!bucketName) throw new Error("No bucket name was set");
-  if (Number(limit) < 0) throw new Error("Allowance cannot be negative");
+  if (Number(limit) <= 0) throw new Error("Allowance must be greater than zero");
   const storedBuckets = (await getBucketsFromLocalStorage()) || {};
   const historyBuckets = normalizeBucketValue(storedBuckets[bucketName] ?? 0);
 
@@ -184,7 +184,7 @@ const addBucketData = async ({ bucket }) => {
   const [name, value] = Object.entries(bucket)[0] || [];
   const trimmedName = (name || "").trim();
   if (!trimmedName) throw new Error("Category name cannot be empty");
-  if (Number(value) < 0) throw new Error("Allowance cannot be negative");
+  if (Number(value) <= 0) throw new Error("Allowance must be greater than zero");
 
   const storedBuckets = (await getBucketsFromLocalStorage()) || {};
   const alreadyExists = Object.keys(storedBuckets).some(


### PR DESCRIPTION
Fixes #155

## Summary
- When a bucket's carried-over debt already exceeds its allowance (availability ≤ 0), the usage percentage previously fell back to `0%` whenever nothing had been spent yet that month, hiding the overspend and suppressing the danger/red indicator.
- The percentage now reads as `100% + how far past the allowance the carried debt goes`, so it scales with severity instead of collapsing every case to a fixed number. Example: a $300 debt against a $200 allowance now shows `150%`; a $10 debt on the same allowance would show `105%` (matching the existing in-month-overspend behavior, which was already unaffected and untouched by this change).
- Also included in this branch (from earlier discussion): bucket allowances are now rejected at both the form level (AddBucket/EditBucket, clear inline error) and the storage layer (`addBucketData`, `editBucketForMonth`) when they are **zero or negative** — an allowance must be strictly greater than zero. This is a prerequisite for the percentage fix above: a zero allowance would make `calculatePercentage(..., allowance)` divide by zero.

## Changes
- `src/components/common/ExpensesManager/Buckets/index.tsx`: replaced the flat `100`/`0` fallback with `100 + calculatePercentage(spending - availability, allowance)` for the zero/negative-availability branch. The positive-availability branch is untouched.
- `src/integrationTests/bucketsCarryOn.test.tsx`: extended the "shows negative availability..." test to assert the new `150%` value and the `danger` CSS class.
- `src/helpers/entriesHelper/entriesHelper.js`, `AddBucket/index.js`, `EditBucket/EditBucket.tsx`, `LocalStorage/index.js`: allowance validation (form + storage) requiring a value strictly greater than zero (`"Allowance must be greater than zero"`), with accompanying unit/integration tests for both the negative and zero cases.
- Version bump to 1.6.3 and CHANGELOG entries, per repo convention.

## Test plan
- [x] `npm test -- --testPathPattern="integrationTests"` — all passing
- [x] `npm test -- --watchAll=false` (full suite) — 283 passed, 14 pre-existing skips
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only)