### PR TITLE
Fix dashboard balance chart percentages to use income as 100% base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.4] - 2026-08-03
+
+### Fixed
+- Dashboard balance chart: percentages are now calculated with incomes as
+  the 100% base, and the chart shows Expenses % / Savings % (instead of the
+  previous Incomes % / Expenses % split against an `incomes + expenses`
+  base, which understated both figures). Overspending (expenses > incomes)
+  and zero incomes are both capped at 100% expenses / 0% savings rather than
+  showing negative savings or hiding the chart (#157)
+
 ## [1.6.3] - 2026-08-02
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-expenses-manager",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "dependencies": {
         "@iconify/react": "^1.1.4",
         "@reduxjs/toolkit": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-expenses-manager",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "private": true,
   "dependencies": {
     "@iconify/react": "^1.1.4",

--- a/src/components/Dashboard/components/DashboardContent/components/BalanceChart/index.js
+++ b/src/components/Dashboard/components/DashboardContent/components/BalanceChart/index.js
@@ -1,27 +1,22 @@
-import { capitalize } from "lodash";
 import DoughnutChart, {
-  INCOME_EXPENSE_COLORS,
+  EXPENSE_SAVINGS_COLORS,
 } from "../../../../../common/DoughnutChart";
-import { ENTRY_TYPES_PLURAL } from "../../../../../../constants";
-import { quantitiesToPercentages } from "../../../../../../helpers/entriesHelper/entriesHelper";
+import { getExpenseSavingsPercentages } from "../../../../../../helpers/entriesHelper/entriesHelper";
 
 const BalanceChart = ({ incomesSum, expensesSum }) => {
   const totalSum = incomesSum + Math.abs(expensesSum);
-  const [incomePercentage, expensePercentage] = quantitiesToPercentages([
+  const [expensePercentage, savingsPercentage] = getExpenseSavingsPercentages(
     incomesSum,
-    expensesSum,
-  ]);
+    expensesSum
+  );
 
   return (
     <DoughnutChart
       data={{
-        labels: [
-          capitalize(ENTRY_TYPES_PLURAL.INCOMES),
-          capitalize(ENTRY_TYPES_PLURAL.EXPENSES),
-        ],
-        chartData: [incomePercentage, expensePercentage],
+        labels: ["Expenses", "Savings"],
+        chartData: [expensePercentage, savingsPercentage],
       }}
-      colors={INCOME_EXPENSE_COLORS}
+      colors={EXPENSE_SAVINGS_COLORS}
       shouldShow={!!totalSum}
     />
   );

--- a/src/components/common/DoughnutChart/index.js
+++ b/src/components/common/DoughnutChart/index.js
@@ -29,6 +29,13 @@ const CATEGORICAL_COLORS = [
  */
 export const INCOME_EXPENSE_COLORS = ["#199e70", "#e66767"];
 
+/**
+ * Semantic pair for expense-vs-savings charts (e.g. the dashboard balance
+ * donut), where expenses are shown in the warning/expense red and savings
+ * reuses the income green to signal "kept" money.
+ */
+export const EXPENSE_SAVINGS_COLORS = ["#e66767", "#199e70"];
+
 const SURFACE_COLOR = "#161b22";
 const LEGEND_TEXT_COLOR = "#9aa4b2";
 

--- a/src/helpers/entriesHelper/entriesHelper.js
+++ b/src/helpers/entriesHelper/entriesHelper.js
@@ -655,6 +655,30 @@ const quantitiesToPercentages = (quantities) => {
   return quantities.map((quantity) => (Math.abs(quantity) / totalSum) * 100);
 };
 
+/**
+ * Function to convert incomes/expenses sums into expense/savings percentages,
+ * using incomes as the 100% base (instead of incomes + expenses).
+ * Overspending (expenses > incomes) and zero incomes are both capped at
+ * 100% expenses / 0% savings, rather than showing negative savings or
+ * hiding the chart.
+ * @param {number} incomesSum
+ * @param {number} expensesSum
+ * @returns {[number, number]} [expensePercentage, savingsPercentage]
+ */
+const getExpenseSavingsPercentages = (incomesSum, expensesSum) => {
+  const incomes = Math.abs(incomesSum);
+  const expenses = Math.abs(expensesSum);
+
+  if (!incomes || expenses >= incomes) {
+    return incomes ? [100, 0] : expenses ? [100, 0] : [0, 0];
+  }
+
+  const expensePercentage = (expenses / incomes) * 100;
+  const savingsPercentage = 100 - expensePercentage;
+
+  return [expensePercentage, savingsPercentage];
+};
+
 export {
   EXPENSE_CATEGORIES,
   INCOME_CATEGORIES,
@@ -670,6 +694,7 @@ export {
   getBucketAllowanceValidationError,
   getGroupedFilledEntriesByDate,
   quantitiesToPercentages,
+  getExpenseSavingsPercentages,
   getFilteredEntriesByCategory,
   getDatedEntries,
   getCategoryPercentagesFromEntries,

--- a/src/helpers/entriesHelper/entriesHelper.test.js
+++ b/src/helpers/entriesHelper/entriesHelper.test.js
@@ -1,6 +1,9 @@
 const balanceResponse = require("./balance-response.json");
 const grouppedFilledEntriesByDate = require("./grouppedFilledEntriesByDate.json");
-const { getGroupedFilledEntriesByDate } = require("./entriesHelper");
+const {
+  getGroupedFilledEntriesByDate,
+  getExpenseSavingsPercentages,
+} = require("./entriesHelper");
 
 describe("Entries helper", () => {
   it("getGroupedFilledEntriesByDate: Should return the dates grouped by date and with no empty dates", () => {
@@ -11,5 +14,31 @@ describe("Entries helper", () => {
 
     jest.useRealTimers();
     expect(processedEntries).toStrictEqual(grouppedFilledEntriesByDate);
+  });
+
+  describe("getExpenseSavingsPercentages", () => {
+    it("should use incomes as the 100% base", () => {
+      expect(getExpenseSavingsPercentages(1000, 250)).toStrictEqual([25, 75]);
+    });
+
+    it("should return 100% savings when there are no expenses", () => {
+      expect(getExpenseSavingsPercentages(1000, 0)).toStrictEqual([0, 100]);
+    });
+
+    it("should cap at 100% expenses / 0% savings when overspending", () => {
+      expect(getExpenseSavingsPercentages(500, 750)).toStrictEqual([100, 0]);
+    });
+
+    it("should cap at 100% expenses / 0% savings when expenses equal incomes", () => {
+      expect(getExpenseSavingsPercentages(500, 500)).toStrictEqual([100, 0]);
+    });
+
+    it("should cap at 100% expenses / 0% savings when incomes are zero but there are expenses", () => {
+      expect(getExpenseSavingsPercentages(0, 200)).toStrictEqual([100, 0]);
+    });
+
+    it("should return 0% expenses / 0% savings when both incomes and expenses are zero", () => {
+      expect(getExpenseSavingsPercentages(0, 0)).toStrictEqual([0, 0]);
+    });
   });
 });

--- a/src/helpers/entriesHelper/entriesHelper.test.js
+++ b/src/helpers/entriesHelper/entriesHelper.test.js
@@ -21,6 +21,14 @@ describe("Entries helper", () => {
       expect(getExpenseSavingsPercentages(1000, 250)).toStrictEqual([25, 75]);
     });
 
+    it("should split evenly when expenses are half of incomes", () => {
+      expect(getExpenseSavingsPercentages(1000, 500)).toStrictEqual([50, 50]);
+    });
+
+    it("should compute the correct split for a non-round percentage", () => {
+      expect(getExpenseSavingsPercentages(1000, 300)).toStrictEqual([30, 70]);
+    });
+
     it("should return 100% savings when there are no expenses", () => {
       expect(getExpenseSavingsPercentages(1000, 0)).toStrictEqual([0, 100]);
     });

--- a/src/integrationTests/balanceChart.test.tsx
+++ b/src/integrationTests/balanceChart.test.tsx
@@ -1,0 +1,51 @@
+import { screen } from "@testing-library/react";
+import { renderApp } from "./helpers/renderApp";
+import { seedEntries, ts, MAY } from "./helpers/seed";
+
+const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.useFakeTimers();
+  jest.setSystemTime(PINNED_DATE);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("dashboard balance chart", () => {
+  it("renders the chart when there are incomes and expenses", async () => {
+    seedEntries([
+      { date: ts(2026, MAY), amount: "1000", type: "income", categories_path: ",salary," },
+      { date: ts(2026, MAY), amount: "250", type: "expense", categories_path: ",food," },
+    ]);
+
+    await renderApp("/");
+
+    expect(await screen.findByText("$1,000.00")).toBeInTheDocument();
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(document.querySelector("canvas")).toBeInTheDocument();
+  });
+
+  it("still renders the chart (capped) when incomes are zero but there are expenses", async () => {
+    seedEntries([
+      { date: ts(2026, MAY), amount: "150", type: "expense", categories_path: ",food," },
+    ]);
+
+    await renderApp("/");
+
+    expect(await screen.findByText("$150.00")).toBeInTheDocument();
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(document.querySelector("canvas")).toBeInTheDocument();
+  });
+
+  it("does not render the chart when there is no income or expense data", async () => {
+    await renderApp("/");
+
+    // Dashboard has loaded (zero balances shown) but the chart has nothing to plot.
+    expect((await screen.findAllByText("$0.00")).length).toBeGreaterThan(0);
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(document.querySelector("canvas")).not.toBeInTheDocument();
+  });
+});

--- a/src/integrationTests/balanceChart.test.tsx
+++ b/src/integrationTests/balanceChart.test.tsx
@@ -2,12 +2,31 @@ import { screen } from "@testing-library/react";
 import { renderApp } from "./helpers/renderApp";
 import { seedEntries, ts, MAY } from "./helpers/seed";
 
+// setupTests.js replaces chart.js with a no-op class (jsdom can't paint
+// <canvas>). Override it here with a spy that records the config each
+// chart instance was constructed with, so we can assert on the actual
+// Expenses/Savings percentages the BalanceChart computed and handed to
+// Chart.js, not just that a canvas exists.
+const mockChartConfigs: any[] = [];
+jest.mock("chart.js/auto", () => ({
+  Chart: class {
+    constructor(_ctx: unknown, config: unknown) {
+      mockChartConfigs.push(config);
+    }
+    update() {}
+    destroy() {}
+  },
+}));
+
 const PINNED_DATE = new Date("2026-05-15T12:00:00Z");
+
+const getLastChartConfig = () => mockChartConfigs[mockChartConfigs.length - 1];
 
 beforeEach(() => {
   localStorage.clear();
   jest.useFakeTimers();
   jest.setSystemTime(PINNED_DATE);
+  mockChartConfigs.length = 0;
 });
 
 afterEach(() => {
@@ -26,6 +45,12 @@ describe("dashboard balance chart", () => {
     expect(await screen.findByText("$1,000.00")).toBeInTheDocument();
     // eslint-disable-next-line testing-library/no-node-access
     expect(document.querySelector("canvas")).toBeInTheDocument();
+
+    // $250 expenses / $1,000 income = 25% expenses, 75% savings — income is
+    // the 100% base, not incomes + expenses (which would give 20% / 80%).
+    const { data } = getLastChartConfig();
+    expect(data.labels).toEqual(["Expenses", "Savings"]);
+    expect(data.datasets[0].data).toEqual([25, 75]);
   });
 
   it("still renders the chart (capped) when incomes are zero but there are expenses", async () => {
@@ -38,6 +63,12 @@ describe("dashboard balance chart", () => {
     expect(await screen.findByText("$150.00")).toBeInTheDocument();
     // eslint-disable-next-line testing-library/no-node-access
     expect(document.querySelector("canvas")).toBeInTheDocument();
+
+    // Zero income is capped at 100% expenses / 0% savings instead of a
+    // division-by-zero blowing up or the chart hiding.
+    const { data } = getLastChartConfig();
+    expect(data.labels).toEqual(["Expenses", "Savings"]);
+    expect(data.datasets[0].data).toEqual([100, 0]);
   });
 
   it("does not render the chart when there is no income or expense data", async () => {


### PR DESCRIPTION
## Summary

- The dashboard's balance chart previously computed income/expense percentages using `incomes + expenses` as the 100% base, which understated real spending and hid savings entirely.
- Incomes are now the 100% base. The chart shows **Expenses %** and **Savings %** instead of Incomes % / Expenses %.
- Overspending and zero-income cases are capped at 100% expenses / 0% savings rather than showing negative values or hiding the chart.
- Added a dedicated `getExpenseSavingsPercentages` helper; left `quantitiesToPercentages` untouched since it's still used correctly elsewhere (Summary charts).
- Added `EXPENSE_SAVINGS_COLORS` for the new chart segments in `DoughnutChart`.
- Added unit tests for the new helper and an integration test covering the dashboard balance chart.
- Bumped version to 1.6.4 and added a CHANGELOG entry per project conventions.

Closes #157

## Test plan

- [x] `npm run typecheck` — clean (only pre-existing unrelated tsconfig deprecation warnings)
- [x] `npm test -- --testPathPattern="integrationTests" --watchAll=false` — 148 tests pass
- [x] `npm test -- --watchAll=false` (full unit suite) — 279 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01SrsRAhs5pitwb6w9N7YcRY)_